### PR TITLE
Transformer implements TransformerBase

### DIFF
--- a/src/clique_miner.rs
+++ b/src/clique_miner.rs
@@ -16,8 +16,7 @@ use lib_dachshund::dachshund::error::CLQResult;
 use lib_dachshund::dachshund::input::Input;
 use lib_dachshund::dachshund::output::Output;
 use lib_dachshund::dachshund::transformer::Transformer;
-use lib_dachshund::dachshund::typed_graph::TypedGraph;
-use lib_dachshund::dachshund::typed_graph_builder::TypedGraphBuilder;
+use lib_dachshund::dachshund::transformer_base::TransformerBase;
 
 fn get_command_line_args() -> ArgMatches<'static> {
     let matches: ArgMatches = App::new("Dachshund")
@@ -107,11 +106,11 @@ fn get_command_line_args() -> ArgMatches<'static> {
 
 fn main() -> CLQResult<()> {
     let matches: ArgMatches = get_command_line_args();
-    let transformer = Transformer::from_argmatches(matches)?;
+    let mut transformer = Transformer::from_argmatches(matches)?;
     let stdio: io::Stdin = io::stdin();
     let input: Input = Input::console(&stdio);
     let mut dummy: Vec<u8> = Vec::new();
-    let mut output: Output = Output::console(&mut dummy);
-    transformer.run::<TypedGraphBuilder, TypedGraph>(input, &mut output)?;
+    let output: Output = Output::console(&mut dummy);
+    transformer.run(input, output)?;
     Ok(())
 }

--- a/src/dachshund/beam.rs
+++ b/src/dachshund/beam.rs
@@ -85,7 +85,7 @@ impl<'a, TGraph: GraphBase> Beam<'a, TGraph> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         graph: &'a TGraph,
-        clique_rows: Vec<CliqueRow>,
+        clique_rows: &'a Vec<CliqueRow>,
         beam_size: usize,
         verbose: bool,
         non_core_types: &'a [String],

--- a/tests/beam.rs
+++ b/tests/beam.rs
@@ -21,6 +21,7 @@ use lib_dachshund::dachshund::test_utils::{
     assert_nodes_have_ids, gen_test_transformer, process_raw_vector,
 };
 use lib_dachshund::dachshund::transformer::Transformer;
+use lib_dachshund::dachshund::transformer_base::TransformerBase;
 use lib_dachshund::dachshund::typed_graph::TypedGraph;
 use lib_dachshund::dachshund::typed_graph_builder::TypedGraphBuilder;
 
@@ -59,7 +60,7 @@ fn test_init_beam_with_clique_rows() -> CLQResult<()> {
 
     let beam: Beam<TypedGraph> = Beam::new(
         &graph,
-        clique_rows,
+        &clique_rows,
         20,
         false,
         &target_types,
@@ -106,7 +107,7 @@ fn test_init_beam_with_partially_overlapping_clique_rows() -> CLQResult<()> {
         transformer.build_pruned_graph::<TypedGraphBuilder, TypedGraph>(graph_id, &rows)?;
     let beam: Beam<TypedGraph> = Beam::new(
         &graph,
-        clique_rows,
+        &clique_rows,
         20,
         false,
         &target_types,
@@ -148,7 +149,7 @@ fn test_init_beam_with_clique_rows_input() -> CLQResult<()> {
             "0\t4\tarticle".into(),
         ];
         // transformer with no epochs
-        let transformer = Transformer::new(
+        let mut transformer = Transformer::new(
             typespec,
             20,
             1.0,
@@ -166,8 +167,8 @@ fn test_init_beam_with_clique_rows_input() -> CLQResult<()> {
         let bytes = text.as_bytes();
         let input = Input::string(&bytes);
         let mut buffer: Vec<u8> = Vec::new();
-        let mut output = Output::string(&mut buffer);
-        transformer.run::<TypedGraphBuilder, TypedGraph>(input, &mut output)?;
+        let output = Output::string(&mut buffer);
+        transformer.run(input, output)?;
         let output_str: String = String::from_utf8(buffer)?;
         assert_eq!(output_str, expected.join("\n") + "\n");
         Ok(())
@@ -200,7 +201,7 @@ fn test_init_beam_with_clique_rows_input_one_epoch() -> CLQResult<()> {
         "0\t4\tarticle".into(),
     ];
     // transformer with no epochs
-    let transformer = Transformer::new(
+    let mut transformer = Transformer::new(
         typespec,
         20,
         1.0,
@@ -219,8 +220,8 @@ fn test_init_beam_with_clique_rows_input_one_epoch() -> CLQResult<()> {
     let bytes = text.as_bytes();
     let input = Input::string(&bytes);
     let mut buffer: Vec<u8> = Vec::new();
-    let mut output = Output::string(&mut buffer);
-    transformer.run::<TypedGraphBuilder, TypedGraph>(input, &mut output)?;
+    let output = Output::string(&mut buffer);
+    transformer.run(input, output)?;
     let output_str: String = String::from_utf8(buffer)?;
     assert_eq!(output_str, expected.join("\n") + "\n");
     Ok(())

--- a/tests/candidate.rs
+++ b/tests/candidate.rs
@@ -75,7 +75,7 @@ fn test_rebuild_candidate() -> CLQResult<()> {
     assert_eq!(output_rows[0].graph_id, graph_id);
     assert_eq!(output_rows[0].node_id, NodeId::from(1));
     assert_eq!(output_rows[0].target_type, None);
-    let new_candidate = Candidate::from_clique_rows(output_rows, &graph, &scorer)?.unwrap();
+    let new_candidate = Candidate::from_clique_rows(&output_rows, &graph, &scorer)?.unwrap();
     println!("Candidate: {}", candidate);
     println!("New candidate: {}", new_candidate);
     assert!(candidate.eq(&new_candidate));


### PR DESCRIPTION
Switching `Transformer` to implementing the `TransformerBase` trait, which is already implemented by `SimpleTransformer`. 

Classes implementing `TransformerBase` are supposed to be state objects that keep track of lines seen so far. `TransformerBase` itself unifies the logic for serially processing a stream of data sorted on a key. I.e., the tiresome batching operation, "if key has changed, then run this thing."

Implementing `TransformerBase` requires the client to specify the logic for:
- setting the `LineProcessor` (which turns lines of text into `Row`s).
- processing a `Row`, by updating the object's state.
- resetting the object's state (note the trait knows nothing about said state).
- what to do with a batch when it's actually ready to be processed?

I had to change things extensively, including tests, but everything still runs as before. 