### PR TITLE
Fixing Transformer bookkeeping when graph is empty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+target/

--- a/src/dachshund/graph_builder.rs
+++ b/src/dachshund/graph_builder.rs
@@ -33,10 +33,10 @@ where
         let mut node_map: HashMap<NodeId, Node> = HashMap::new();
         for &id in core_ids {
             let node = Node::new(
-                id,         // node_id,
-                true,       // is_core,
-                None,       // non_core_type,
-                Vec::new(), // edges,
+                id,             // node_id,
+                true,           // is_core,
+                None,           // non_core_type,
+                Vec::new(),     // edges,
                 HashMap::new(), //neighbors
             );
             node_map.insert(id, node);
@@ -65,11 +65,11 @@ where
                 .get_mut(&r.source_id)
                 .ok_or_else(CLQError::err_none)?;
 
-
-            if !source_node.neighbors.contains_key(&r.target_id){
+            if !source_node.neighbors.contains_key(&r.target_id) {
                 source_node.neighbors.insert(r.target_id, Vec::new());
             }
-            source_node.neighbors
+            source_node
+                .neighbors
                 .get_mut(&r.target_id)
                 .unwrap()
                 .push(NodeEdge::new(r.edge_type_id, r.target_id));
@@ -87,15 +87,17 @@ where
                     .get_mut(&r.target_id)
                     .ok_or_else(CLQError::err_none)?;
 
-                if !target_node.neighbors.contains_key(&r.source_id){
+                if !target_node.neighbors.contains_key(&r.source_id) {
                     target_node.neighbors.insert(r.source_id, Vec::new());
                 }
-                target_node.neighbors
+                target_node
+                    .neighbors
                     .get_mut(&r.source_id)
                     .unwrap()
                     .push(NodeEdge::new(r.edge_type_id, r.source_id));
 
-                target_node.edges
+                target_node
+                    .edges
                     .push(NodeEdge::new(r.edge_type_id, r.source_id));
             }
         }

--- a/src/dachshund/node.rs
+++ b/src/dachshund/node.rs
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 use std::cmp::{Eq, PartialEq};
-use std::collections::{HashSet, HashMap};
+use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
 
 use crate::dachshund::error::{CLQError, CLQResult};
@@ -34,7 +34,7 @@ pub struct Node {
     pub is_core: bool,
     pub non_core_type: Option<NodeTypeId>,
     pub edges: Vec<NodeEdge>,
-    pub neighbors: HashMap<NodeId,Vec<NodeEdge>>,
+    pub neighbors: HashMap<NodeId, Vec<NodeEdge>>,
 }
 impl Hash for Node {
     fn hash<H: Hasher>(&self, state: &mut H) {
@@ -54,7 +54,7 @@ impl Node {
         is_core: bool,
         non_core_type: Option<NodeTypeId>,
         edges: Vec<NodeEdge>,
-        neighbors: HashMap<NodeId,Vec<NodeEdge>>,
+        neighbors: HashMap<NodeId, Vec<NodeEdge>>,
     ) -> Node {
         Node {
             node_id,
@@ -83,7 +83,7 @@ impl Node {
                     None => (),
                 }
             }
-        } ;
+        };
         num_ties
     }
     pub fn is_core(&self) -> bool {

--- a/src/dachshund/scorer.rs
+++ b/src/dachshund/scorer.rs
@@ -74,7 +74,10 @@ impl Scorer {
         }
     }
     // used to ensure that each core node has at least % of ties with non-core nodes.
-    pub fn get_local_thresh_score<TGraph: GraphBase>(&self, candidate: &mut Candidate<TGraph>) -> f32 {
+    pub fn get_local_thresh_score<TGraph: GraphBase>(
+        &self,
+        candidate: &mut Candidate<TGraph>,
+    ) -> f32 {
         match self.local_thresh {
             Some(thresh) => candidate.local_thresh_score_at_least(thresh) as i64 as f32,
             None => 1.0,

--- a/src/dachshund/simple_transformer.rs
+++ b/src/dachshund/simple_transformer.rs
@@ -115,7 +115,8 @@ impl TransformerBase for SimpleTransformer {
         self.batch.clear();
         Ok(())
     }
-    fn process_batch(&self, graph_id: GraphId, output: &Sender<(String, bool)>) -> CLQResult<()> {
+    fn process_batch(&self, graph_id: GraphId,
+                     output: &Sender<(Option<String>, bool)>) -> CLQResult<()> {
         let tuples: Vec<(i64, i64)> = self.batch.iter().map(|x| x.as_tuple()).collect();
         let graph = SimpleUndirectedGraphBuilder::from_vector(&tuples);
         let stats = Self::compute_graph_stats_json(&graph);
@@ -123,7 +124,7 @@ impl TransformerBase for SimpleTransformer {
             .line_processor
             .get_original_id(graph_id.value() as usize);
         let line: String = format!("{}\t{}", original_id, stats);
-        output.send((line, false)).unwrap();
+        output.send((Some(line), false)).unwrap();
         Ok(())
     }
 }
@@ -139,7 +140,7 @@ impl TransformerBase for SimpleParallelTransformer {
         self.batch.clear();
         Ok(())
     }
-    fn process_batch(&self, graph_id: GraphId, output: &Sender<(String, bool)>) -> CLQResult<()> {
+    fn process_batch(&self, graph_id: GraphId, output: &Sender<(Option<String>, bool)>) -> CLQResult<()> {
         let tuples: Vec<(i64, i64)> = self.batch.iter().map(|x| x.as_tuple()).collect();
         let output_clone = output.clone();
         let line_processor = self.line_processor.clone();
@@ -148,7 +149,7 @@ impl TransformerBase for SimpleParallelTransformer {
             let stats = Self::compute_graph_stats_json(&graph);
             let original_id = line_processor.get_original_id(graph_id.value() as usize);
             let line: String = format!("{}\t{}", original_id, stats);
-            output_clone.send((line, false)).unwrap();
+            output_clone.send((Some(line), false)).unwrap();
         });
         Ok(())
     }

--- a/src/dachshund/simple_undirected_graph_builder.rs
+++ b/src/dachshund/simple_undirected_graph_builder.rs
@@ -75,8 +75,8 @@ impl SimpleUndirectedGraphBuilder {
     pub fn get_complete_graph(n: u64) -> SimpleUndirectedGraph {
         let mut v = Vec::new();
         for i in 1..n {
-            for j in i+1..=n {
-                v.push((i,j));
+            for j in i + 1..=n {
+                v.push((i, j));
             }
         }
         SimpleUndirectedGraphBuilder::from_vector(
@@ -89,7 +89,7 @@ impl SimpleUndirectedGraphBuilder {
     pub fn get_path_graph(n: u64) -> SimpleUndirectedGraph {
         let mut v = Vec::new();
         for i in 0..n {
-            v.push((i, (i+1)));
+            v.push((i, (i + 1)));
         }
 
         SimpleUndirectedGraphBuilder::from_vector(
@@ -103,7 +103,7 @@ impl SimpleUndirectedGraphBuilder {
     pub fn get_cycle_graph(n: u64) -> SimpleUndirectedGraph {
         let mut v = Vec::new();
         for i in 0..n {
-            v.push((i, (i+1) % n));
+            v.push((i, (i + 1) % n));
         }
 
         SimpleUndirectedGraphBuilder::from_vector(
@@ -121,8 +121,10 @@ impl SimpleUndirectedGraphBuilder {
         let mut rng = rand::thread_rng();
 
         for i in 1..n {
-            for j in i+1..=n {
-                if rng.gen::<f64>() < p {v.push((i,j));}
+            for j in i + 1..=n {
+                if rng.gen::<f64>() < p {
+                    v.push((i, j));
+                }
             }
         }
 
@@ -130,5 +132,4 @@ impl SimpleUndirectedGraphBuilder {
             &v.into_iter().map(|(x, y)| (x as i64, y as i64)).collect(),
         )
     }
-
 }

--- a/tests/candidate.rs
+++ b/tests/candidate.rs
@@ -95,12 +95,13 @@ fn build_sample_graph() -> CLQResult<TypedGraph>{
         vec!["author".to_string(), "published".into(), "article".into()],
         vec!["author".to_string(), "cited".into(), "article".into()],
     ];
-    let raw: Vec<String> = vec!["0\t1\t2\tauthor\tpublished\tarticle".to_string(),
-                                "0\t1\t4\tauthor\tpublished\tarticle".to_string(),
-                                "0\t1\t4\tauthor\tcited\tarticle".to_string(),
-                                "0\t3\t4\tauthor\tpublished\tarticle".to_string(),
-                                "0\t3\t6\tauthor\tpublished\tarticle".to_string(),
-                                "0\t5\t6\tauthor\tpublished\tarticle".to_string(),
+    let raw: Vec<String> = vec![
+        "0\t1\t2\tauthor\tpublished\tarticle".to_string(),
+        "0\t1\t4\tauthor\tpublished\tarticle".to_string(),
+        "0\t1\t4\tauthor\tcited\tarticle".to_string(),
+        "0\t3\t4\tauthor\tpublished\tarticle".to_string(),
+        "0\t3\t6\tauthor\tpublished\tarticle".to_string(),
+        "0\t5\t6\tauthor\tpublished\tarticle".to_string(),
     ];
     let graph_id: GraphId = 0.into();
 
@@ -124,34 +125,34 @@ fn test_neighborhood() -> CLQResult<()> {
     assert_eq!(graph.core_ids.len(), 3);
     assert_eq!(graph.non_core_ids.len(), 3);
 
-    let initial_id : NodeId = 1.into();
+    let initial_id: NodeId = 1.into();
     let alpha: f32 = 1.0;
     let scorer: Scorer = Scorer::new(2, alpha, Some(0.0), Some(0.0));
 
     let mut candidate: Candidate<TypedGraph> = Candidate::new(initial_id, &graph, &scorer)?;
 
     let neighborhood = candidate.get_neighborhood();
-    let mut expected_neighborhood : HashMap<NodeId, usize> = HashMap::new();
-    expected_neighborhood.insert(2.into(),1);
-    expected_neighborhood.insert(4.into(),2);
+    let mut expected_neighborhood: HashMap<NodeId, usize> = HashMap::new();
+    expected_neighborhood.insert(2.into(), 1);
+    expected_neighborhood.insert(4.into(), 2);
     assert_eq!(neighborhood, expected_neighborhood);
 
     // Adding 4 to the clique, so 4 is no longer adjacent and 3 should
     // be added with value 1.
     candidate.add_node(4.into())?;
     let neighborhood = candidate.get_neighborhood();
-    let mut expected_neighborhood : HashMap<NodeId, usize> = HashMap::new();
-    expected_neighborhood.insert(2.into(),1);
-    expected_neighborhood.insert(3.into(),1);
+    let mut expected_neighborhood: HashMap<NodeId, usize> = HashMap::new();
+    expected_neighborhood.insert(2.into(), 1);
+    expected_neighborhood.insert(3.into(), 1);
     assert_eq!(neighborhood, expected_neighborhood);
 
     // Adding 3 to the clique, so 3 is no longer adjacent and 6 should
     // be added with value 1.
     candidate.add_node(3.into())?;
     let neighborhood = candidate.get_neighborhood();
-    let mut expected_neighborhood : HashMap<NodeId, usize> = HashMap::new();
-    expected_neighborhood.insert(2.into(),1);
-    expected_neighborhood.insert(6.into(),1);
+    let mut expected_neighborhood: HashMap<NodeId, usize> = HashMap::new();
+    expected_neighborhood.insert(2.into(), 1);
+    expected_neighborhood.insert(6.into(), 1);
     assert_eq!(neighborhood, expected_neighborhood);
 
     Ok(())

--- a/tests/karate_club.rs
+++ b/tests/karate_club.rs
@@ -464,10 +464,10 @@ fn test_connected_components() {
 fn test_transitivity() {
     let graph = get_karate_club_graph();
     let trans = graph.get_transitivity();
-    println!("{}", trans);  
+    println!("{}", trans);
     assert!((trans - 0.2556818181818182).abs() <= f64::EPSILON);
-    
+
     let approx_trans = graph.get_approx_transitivity(1000);
-    println!("{}", approx_trans);  
+    println!("{}", approx_trans);
     assert!((approx_trans - trans).abs() <= 0.05);
 }

--- a/tests/pruning.rs
+++ b/tests/pruning.rs
@@ -136,7 +136,7 @@ fn test_full_prune_small_clique() -> CLQResult<()> {
 
     // with pruning at degree < 3
     let (sender_prune, _receiver_prune) = channel();
-    
+
     let transformer_prune = Transformer::new(
         ts.clone(),
         20,
@@ -165,7 +165,7 @@ fn test_full_prune_small_clique() -> CLQResult<()> {
             &sender_prune,
         )?
         .ok_or_else(CLQError::err_none)?;
-    sender_prune.send(("".to_string(), true)).unwrap();
+    sender_prune.send((None, true)).unwrap();
     let candidate_prune = result_prune.top_candidate;
     assert_nodes_have_ids(&graph, &candidate_prune.core_ids, vec![1, 2], true);
     assert_nodes_have_ids(&graph, &candidate_prune.non_core_ids, vec![3], false);
@@ -192,15 +192,9 @@ fn test_full_prune_small_clique() -> CLQResult<()> {
         transformer.build_pruned_graph::<TypedGraphBuilder, TypedGraph>(graph_id, &rows)?;
     let v = Vec::new();
     let result = transformer
-        .process_clique_rows::<TypedGraphBuilder, TypedGraph>(
-            &graph,
-            &v,
-            graph_id,
-            false,
-            &sender,
-        )?
+        .process_clique_rows::<TypedGraphBuilder, TypedGraph>(&graph, &v, graph_id, false, &sender)?
         .ok_or_else(CLQError::err_none)?;
-    sender.send(("".to_string(), true)).unwrap();
+    sender.send((None, true)).unwrap();
     let candidate = result.top_candidate;
     assert_nodes_have_ids(&graph, &candidate.core_ids, vec![1, 2], true);
     assert_nodes_have_ids(&graph, &candidate.non_core_ids, vec![3], false);

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -114,12 +114,15 @@ fn test_process_single_line_clique_row() -> CLQResult<()> {
 }
 
 fn test_expected_clique<F>(transformer: Transformer, raw: Vec<String>, f: F) -> CLQResult<()>
-    where F: Fn(&TypedGraph, &Candidate<TypedGraph>) -> () {
+where
+    F: Fn(&TypedGraph, &Candidate<TypedGraph>) -> (),
+{
     let graph_id: GraphId = 0.into();
 
     let rows = process_raw_vector(&transformer, raw).unwrap();
-    let graph: TypedGraph =
-        transformer.build_pruned_graph::<TypedGraphBuilder, TypedGraph>(graph_id, &rows).unwrap();
+    let graph: TypedGraph = transformer
+        .build_pruned_graph::<TypedGraphBuilder, TypedGraph>(graph_id, &rows)
+        .unwrap();
     let clique_rows = Vec::new();
     let (sender, _receiver) = channel();
     let res: Candidate<TypedGraph> = transformer
@@ -129,10 +132,12 @@ fn test_expected_clique<F>(transformer: Transformer, raw: Vec<String>, f: F) -> 
             graph_id,
             true,
             &sender,
-        ).unwrap()
-        .ok_or_else(CLQError::err_none).unwrap()
+        )
+        .unwrap()
+        .ok_or_else(CLQError::err_none)
+        .unwrap()
         .top_candidate;
-    sender.send(("".to_string(), true)).unwrap();
+    sender.send((None, true)).unwrap();
     f(&graph, &res);
     Ok(())
 }
@@ -145,7 +150,7 @@ fn test_process_single_row() -> CLQResult<()> {
         |graph, res| {
             assert_nodes_have_ids(graph, &res.core_ids, vec![1], true);
             assert_nodes_have_ids(graph, &res.non_core_ids, vec![2], false);
-        }
+        },
     )
 }
 
@@ -160,9 +165,9 @@ fn test_process_small_clique() -> CLQResult<()> {
             "0\t2\t4\tauthor\tpublished_at\tconference".into(),
         ],
         |graph, res| {
-            assert_nodes_have_ids(graph, &res.core_ids, vec![1,2], true);
-            assert_nodes_have_ids(graph, &res.non_core_ids, vec![3,4], false);
-        }
+            assert_nodes_have_ids(graph, &res.core_ids, vec![1, 2], true);
+            assert_nodes_have_ids(graph, &res.non_core_ids, vec![3, 4], false);
+        },
     )
 }
 
@@ -179,9 +184,9 @@ fn test_process_small_clique_with_non_clique_row() -> CLQResult<()> {
             "0\t2\t5\tconference\tpublished_at\tconference".into(),
         ],
         |graph, res| {
-            assert_nodes_have_ids(graph, &res.core_ids, vec![1,2], true);
-            assert_nodes_have_ids(graph, &res.non_core_ids, vec![3,4], false);
-        }
+            assert_nodes_have_ids(graph, &res.core_ids, vec![1, 2], true);
+            assert_nodes_have_ids(graph, &res.non_core_ids, vec![3, 4], false);
+        },
     )
 }
 
@@ -203,12 +208,20 @@ fn test_process_medium_clique() -> CLQResult<()> {
         gen_test_transformer(ts, "author".to_string()).unwrap(),
         clique_rows,
         |graph, res| {
-            assert_nodes_have_ids(graph, &res.core_ids,
-                                  core_ids.iter().map(|x| x.value()).collect(), true);
-            assert_nodes_have_ids(graph, &res.non_core_ids,
-                                  non_cores.iter().map(|x| x.0.value()).collect(), false);
-        }
-    ) 
+            assert_nodes_have_ids(
+                graph,
+                &res.core_ids,
+                core_ids.iter().map(|x| x.value()).collect(),
+                true,
+            );
+            assert_nodes_have_ids(
+                graph,
+                &res.non_core_ids,
+                non_cores.iter().map(|x| x.0.value()).collect(),
+                false,
+            );
+        },
+    )
 }
 
 #[test]
@@ -227,24 +240,24 @@ fn test_process_medium_clique_with_insufficient_epochs() -> CLQResult<()> {
     assert_eq!(clique_rows.len(), 200);
     test_expected_clique(
         Transformer::new(
-			ts,
-			20,
-			1.0,
-			Some(1.0),
-			Some(1.0),
-			20,
-			10,
-			3,
-			true, // with 10 epochs
-			0,    // min_degree = 0
-			"author".to_string(),
-			false,
-		)?,
+            ts,
+            20,
+            1.0,
+            Some(1.0),
+            Some(1.0),
+            20,
+            10,
+            3,
+            true, // with 10 epochs
+            0,    // min_degree = 0
+            "author".to_string(),
+            false,
+        )?,
         clique_rows,
         |_graph, res| {
             assert_eq!(res.core_ids.len() + res.non_core_ids.len(), 11);
-        }
-    ) 
+        },
+    )
 }
 
 #[test]
@@ -269,8 +282,8 @@ fn test_process_small_clique_with_two_kinds_of_rows() -> CLQResult<()> {
         |graph, res| {
             assert_nodes_have_ids(graph, &res.core_ids, vec![1, 2], true);
             assert_nodes_have_ids(graph, &res.non_core_ids, vec![3], false);
-        }
-    ) 
+        },
+    )
 }
 
 #[test]
@@ -294,6 +307,6 @@ fn test_process_another_small_clique_with_two_kinds_of_rows() -> CLQResult<()> {
         |graph, res| {
             assert_nodes_have_ids(graph, &res.core_ids, vec![2, 3], true);
             assert_nodes_have_ids(graph, &res.non_core_ids, vec![5], false);
-        }
-    ) 
+        },
+    )
 }

--- a/tests/triangles.rs
+++ b/tests/triangles.rs
@@ -9,24 +9,18 @@
 extern crate lib_dachshund;
 extern crate test;
 
+use lib_dachshund::dachshund::id_types::NodeId;
 use lib_dachshund::dachshund::simple_undirected_graph::SimpleUndirectedGraph;
 use lib_dachshund::dachshund::simple_undirected_graph_builder::SimpleUndirectedGraphBuilder;
-use lib_dachshund::dachshund::id_types::{NodeId};
 
 use test::Bencher;
 
 // The complete graph on 4 nodes with one edge removed.
 // This is the minimal counterexample where T(G) != C(G).
 fn get_almost_k4_graph() -> SimpleUndirectedGraph {
-    let v = vec![
-            (0, 1),
-            (0, 2),
-            (0, 3),
-            (1, 2),
-            (1, 3),
-        ];
+    let v = vec![(0, 1), (0, 2), (0, 3), (1, 2), (1, 3)];
     SimpleUndirectedGraphBuilder::from_vector(
-        &v.into_iter().map(|(x, y)| (x as i64, y as i64)).collect()
+        &v.into_iter().map(|(x, y)| (x as i64, y as i64)).collect(),
     )
 }
 
@@ -40,9 +34,7 @@ fn test_triangle_count() {
     let almost_k4 = get_almost_k4_graph();
     for i in 0..4 {
         let id = NodeId::from(i as i64);
-        assert_eq!(if i <= 1 {2} else {1},
-                    almost_k4.triangle_count(id));
-
+        assert_eq!(if i <= 1 { 2 } else { 1 }, almost_k4.triangle_count(id));
     }
 }
 
@@ -57,7 +49,7 @@ fn bench_triangle_count(b: &mut Bencher) {
 }
 
 #[test]
-fn test_clustering_coefficient(){
+fn test_clustering_coefficient() {
     let k4 = &SimpleUndirectedGraphBuilder::get_complete_graph(4);
     for node_id in k4.nodes.keys() {
         assert_eq!(1.0, k4.get_clustering_coefficient(*node_id).unwrap());
@@ -66,14 +58,11 @@ fn test_clustering_coefficient(){
 
     let almost_k4 = &get_almost_k4_graph();
 
-    assert!(
-        ((5 as f64 / 6 as f64) - almost_k4.get_avg_clustering()).abs()
-        <= 0.00001
-    );
+    assert!(((5 as f64 / 6 as f64) - almost_k4.get_avg_clustering()).abs() <= 0.00001);
 }
 
 #[test]
-fn test_transitivity(){
+fn test_transitivity() {
     let k4 = &SimpleUndirectedGraphBuilder::get_complete_graph(4);
     assert_eq!(1.0, k4.get_transitivity());
 
@@ -82,32 +71,24 @@ fn test_transitivity(){
 }
 
 #[test]
-fn test_approx_avg_clustering(){
+fn test_approx_avg_clustering() {
     let k4 = &SimpleUndirectedGraphBuilder::get_complete_graph(4);
     assert_eq!(1.0, k4.get_approx_avg_clustering(10));
 
     let almost_k4 = &get_almost_k4_graph();
     let approx_clustering = almost_k4.get_approx_avg_clustering(10000);
-    assert!(
-        ((5 as f64 / 6 as f64) - approx_clustering).abs()
-        <= 0.01
-    );
+    assert!(((5 as f64 / 6 as f64) - approx_clustering).abs() <= 0.01);
 }
 
 #[test]
-fn test_approx_transitivity(){
+fn test_approx_transitivity() {
     let k4 = &SimpleUndirectedGraphBuilder::get_complete_graph(4);
     assert_eq!(1.0, k4.get_approx_transitivity(10));
 
     let almost_k4 = &get_almost_k4_graph();
-    let approx_transitivity = almost_k4.get_approx_transitivity(10000);
+    let approx_transitivity = almost_k4.get_approx_transitivity(100000);
 
     println!("{}", approx_transitivity);
 
-    assert!(
-        (0.75 - approx_transitivity).abs()
-        <= 0.01
-    );
-
-
+    assert!((0.75 - approx_transitivity).abs() <= 0.01);
 }


### PR DESCRIPTION
The new `TransformerBase` class relies on a multi-producer/single-consumer infrastructure using channels to (potentially) distribute work to multiple threads (at the moment this is not done, but should be feasible). The consumer increments an atomic counter keeping track of how many graphs have been processed so far, *whenever it receives a line of input from a producer* (`transformer_base.rs:47`). We're only done when this counter equals the `num_to_process` counter kept by the transformer before parallelization.

The problem is, what happens when a graph ends up empty after pruning? The prior implementation just ignored that graph, which resulted in the `num_processed` counter never catching up with `num_to_process`. This in turn meant the transformer would be stuck in an eternal sleep loop.

The fix was quite easy: emit an empty line on the channel, whenever the graph is empty -- effectively acknowledging that the graph was indeed processed.

I wrote a test to reproduce the problem (in `tests/beam.rs:230-271`) and fixed the problem in `transformer.rs:283-287`). The rest of the changes are cosmetic, from running `cargo fmt` on the code and can be ignored in the review.