### PR TITLE
SimpleUndirectedGraph now uses SimpleNode

### DIFF
--- a/src/dachshund/algorithms/clustering.rs
+++ b/src/dachshund/algorithms/clustering.rs
@@ -8,8 +8,8 @@ extern crate nalgebra as na;
 use crate::dachshund::graph_base::GraphBase;
 use crate::dachshund::id_types::NodeId;
 use crate::dachshund::node::{NodeBase, NodeEdgeBase};
-use rand::Rng;
 use rand::prelude::*;
+use rand::Rng;
 use std::collections::HashSet;
 
 pub trait Clustering: GraphBase {

--- a/src/dachshund/algorithms/cnm_communities.rs
+++ b/src/dachshund/algorithms/cnm_communities.rs
@@ -7,7 +7,7 @@
 extern crate nalgebra as na;
 use crate::dachshund::graph_base::GraphBase;
 use crate::dachshund::id_types::NodeId;
-use crate::dachshund::node::{SimpleNode, NodeBase, NodeEdgeBase};
+use crate::dachshund::node::{NodeBase, NodeEdgeBase, SimpleNode};
 use ordered_float::OrderedFloat;
 use std::cmp::Ordering;
 use std::collections::{BinaryHeap, HashMap, HashSet};

--- a/src/dachshund/algorithms/cnm_communities.rs
+++ b/src/dachshund/algorithms/cnm_communities.rs
@@ -7,7 +7,7 @@
 extern crate nalgebra as na;
 use crate::dachshund::graph_base::GraphBase;
 use crate::dachshund::id_types::NodeId;
-use crate::dachshund::node::{Node, NodeBase, NodeEdgeBase};
+use crate::dachshund::node::{SimpleNode, NodeBase, NodeEdgeBase};
 use ordered_float::OrderedFloat;
 use std::cmp::Ordering;
 use std::collections::{BinaryHeap, HashMap, HashSet};
@@ -76,7 +76,7 @@ pub struct CNMCommunityIntermediaryState {
     pub num_edges: usize,
 }
 
-pub trait CNMCommunities: GraphBase<NodeType = Node> {
+pub trait CNMCommunities: GraphBase<NodeType = SimpleNode> {
     fn get_max_maxheap(
         &self,
         delta_q_maxheap: &HashMap<usize, CNMCommunityMergeInstructionHeap>,

--- a/src/dachshund/graph_builder.rs
+++ b/src/dachshund/graph_builder.rs
@@ -26,7 +26,6 @@ where
         non_core_ids: Vec<NodeId>,
     ) -> CLQResult<TGraph>;
 
-
     // initializes nodes in the graph with empty neighbors fields.
     fn init_nodes(
         core_ids: &[NodeId],

--- a/src/dachshund/graph_builder.rs
+++ b/src/dachshund/graph_builder.rs
@@ -25,6 +25,8 @@ where
         core_ids: Vec<NodeId>,
         non_core_ids: Vec<NodeId>,
     ) -> CLQResult<TGraph>;
+
+
     // initializes nodes in the graph with empty neighbors fields.
     fn init_nodes(
         core_ids: &[NodeId],

--- a/src/dachshund/node.rs
+++ b/src/dachshund/node.rs
@@ -16,8 +16,10 @@ pub struct NodeEdge {
     pub edge_type: EdgeTypeId,
     pub target_id: NodeId,
 }
-pub trait NodeEdgeBase 
-where Self: Sized {
+pub trait NodeEdgeBase
+where
+    Self: Sized,
+{
     fn get_neighbor_id(&self) -> NodeId;
 }
 impl NodeEdgeBase for NodeEdge {
@@ -40,8 +42,9 @@ impl NodeEdgeBase for NodeId {
     }
 }
 
-pub trait NodeBase where
-    Self: Sized
+pub trait NodeBase
+where
+    Self: Sized,
 {
     type NodeEdgeType: NodeEdgeBase + Sized;
 
@@ -168,6 +171,9 @@ impl NodeBase for SimpleNode {
     /// used to determine degree in a subgraph (i.e., the clique we're considering).
     /// HashSet is supplied by Candidate struct.
     fn count_ties_with_ids(&self, ids: &HashSet<NodeId>) -> usize {
-        ids.iter().filter(|x| self.neighbors.contains(x)).collect::<Vec<&NodeId>>().len()
+        ids.iter()
+            .filter(|x| self.neighbors.contains(x))
+            .collect::<Vec<&NodeId>>()
+            .len()
     }
 }

--- a/src/dachshund/simple_undirected_graph.rs
+++ b/src/dachshund/simple_undirected_graph.rs
@@ -18,7 +18,7 @@ use crate::dachshund::algorithms::shortest_paths::ShortestPaths;
 use crate::dachshund::algorithms::transitivity::Transitivity;
 use crate::dachshund::graph_base::GraphBase;
 use crate::dachshund::id_types::NodeId;
-use crate::dachshund::node::{SimpleNode, NodeBase, NodeEdgeBase};
+use crate::dachshund::node::{NodeBase, NodeEdgeBase, SimpleNode};
 use std::collections::hash_map::{Keys, Values};
 use std::collections::HashMap;
 

--- a/src/dachshund/simple_undirected_graph.rs
+++ b/src/dachshund/simple_undirected_graph.rs
@@ -18,17 +18,17 @@ use crate::dachshund::algorithms::shortest_paths::ShortestPaths;
 use crate::dachshund::algorithms::transitivity::Transitivity;
 use crate::dachshund::graph_base::GraphBase;
 use crate::dachshund::id_types::NodeId;
-use crate::dachshund::node::{Node, NodeBase};
+use crate::dachshund::node::{SimpleNode, NodeBase, NodeEdgeBase};
 use std::collections::hash_map::{Keys, Values};
 use std::collections::HashMap;
 
 /// Keeps track of a simple undirected graph, composed of nodes without any type information.
 pub struct SimpleUndirectedGraph {
-    pub nodes: HashMap<NodeId, Node>,
+    pub nodes: HashMap<NodeId, SimpleNode>,
     pub ids: Vec<NodeId>,
 }
 impl GraphBase for SimpleUndirectedGraph {
-    type NodeType = Node;
+    type NodeType = SimpleNode;
 
     /// core and non-core IDs are the same for a `SimpleUndirectedGraph`.
     fn get_core_ids(&self) -> &Vec<NodeId> {
@@ -38,19 +38,19 @@ impl GraphBase for SimpleUndirectedGraph {
     fn get_non_core_ids(&self) -> Option<&Vec<NodeId>> {
         Some(&self.ids)
     }
-    fn get_ids_iter(&self) -> Keys<NodeId, Node> {
+    fn get_ids_iter(&self) -> Keys<NodeId, SimpleNode> {
         self.nodes.keys()
     }
-    fn get_nodes_iter(&self) -> Values<NodeId, Node> {
+    fn get_nodes_iter(&self) -> Values<NodeId, SimpleNode> {
         self.nodes.values()
     }
-    fn get_mut_nodes(&mut self) -> &mut HashMap<NodeId, Node> {
+    fn get_mut_nodes(&mut self) -> &mut HashMap<NodeId, SimpleNode> {
         &mut self.nodes
     }
     fn has_node(&self, node_id: NodeId) -> bool {
         self.nodes.contains_key(&node_id)
     }
-    fn get_node(&self, node_id: NodeId) -> &Node {
+    fn get_node(&self, node_id: NodeId) -> &SimpleNode {
         &self.nodes[&node_id]
     }
     fn count_edges(&self) -> usize {
@@ -68,13 +68,13 @@ impl SimpleUndirectedGraph {
     pub fn as_input_rows(&self, graph_id: usize) -> String {
         let mut rows: Vec<String> = Vec::new();
         for (id, node) in &self.nodes {
-            for e in &node.edges {
-                if *id < e.target_id {
+            for e in node.get_edges() {
+                if *id < e.get_neighbor_id() {
                     rows.push(format!(
                         "{}\t{}\t{}",
                         graph_id,
                         id.value(),
-                        e.target_id.value()
+                        e.get_neighbor_id().value()
                     ));
                 }
             }

--- a/src/dachshund/simple_undirected_graph_builder.rs
+++ b/src/dachshund/simple_undirected_graph_builder.rs
@@ -5,63 +5,36 @@
  * LICENSE file in the root directory of this source tree.
  */
 extern crate nalgebra as na;
-use crate::dachshund::error::CLQResult;
-use crate::dachshund::graph_builder::GraphBuilder;
-use crate::dachshund::id_types::{EdgeTypeId, NodeId};
-use crate::dachshund::node::{Node, NodeEdge};
+use crate::dachshund::id_types::NodeId;
+use crate::dachshund::node::SimpleNode;
 use crate::dachshund::simple_undirected_graph::SimpleUndirectedGraph;
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use rand::prelude::*;
 
 pub struct SimpleUndirectedGraphBuilder {}
-impl GraphBuilder<SimpleUndirectedGraph> for SimpleUndirectedGraphBuilder {
-    fn _new(
-        nodes: HashMap<NodeId, Node>,
-        core_ids: Vec<NodeId>,
-        non_core_ids: Vec<NodeId>,
-    ) -> CLQResult<SimpleUndirectedGraph> {
-        assert!(core_ids.len() == non_core_ids.len());
-
-        Ok(SimpleUndirectedGraph {
-            nodes,
-            ids: core_ids,
-        })
-    }
-}
 
 impl SimpleUndirectedGraphBuilder {
     // builds a graph from a vector of IDs. Repeated edges are ignored.
     // Edges only need to be provided once (this being an undirected graph)
     #[allow(clippy::ptr_arg)]
     pub fn from_vector(data: &Vec<(i64, i64)>) -> SimpleUndirectedGraph {
-        let mut ids: BTreeMap<NodeId, HashSet<NodeId>> = BTreeMap::new();
+        let mut ids: BTreeMap<NodeId, BTreeSet<NodeId>> = BTreeMap::new();
         for (id1, id2) in data {
             ids.entry(NodeId::from(*id1))
-                .or_insert_with(HashSet::new)
+                .or_insert_with(BTreeSet::new)
                 .insert(NodeId::from(*id2));
             ids.entry(NodeId::from(*id2))
-                .or_insert_with(HashSet::new)
+                .or_insert_with(BTreeSet::new)
                 .insert(NodeId::from(*id1));
         }
-        let edge_type_id = EdgeTypeId::from(0 as usize);
-        let mut nodes: HashMap<NodeId, Node> = HashMap::new();
+        let mut nodes: HashMap<NodeId, SimpleNode> = HashMap::new();
         for (id, neighbors) in ids.into_iter() {
             nodes.insert(
                 id,
-                Node {
+                SimpleNode {
                     node_id: id,
-                    edges: neighbors
-                        .iter()
-                        .map(|x| NodeEdge::new(edge_type_id, *x))
-                        .collect(),
                     neighbors: neighbors
-                        .iter()
-                        .map(|x| (*x, vec![NodeEdge::new(edge_type_id, *x)]))
-                        .collect(),
-                    // meaningless
-                    is_core: true,
-                    non_core_type: None,
                 },
             );
         }

--- a/src/dachshund/simple_undirected_graph_builder.rs
+++ b/src/dachshund/simple_undirected_graph_builder.rs
@@ -34,7 +34,7 @@ impl SimpleUndirectedGraphBuilder {
                 id,
                 SimpleNode {
                     node_id: id,
-                    neighbors: neighbors
+                    neighbors: neighbors,
                 },
             );
         }

--- a/tests/karate_club.rs
+++ b/tests/karate_club.rs
@@ -27,206 +27,129 @@ use lib_dachshund::dachshund::simple_undirected_graph_builder::SimpleUndirectedG
 use lib_dachshund::dachshund::algorithms::transitivity::Transitivity;
 use lib_dachshund::dachshund::test_utils::{gen_test_transformer, process_raw_vector};
 use lib_dachshund::dachshund::transformer::Transformer;
+use lib_dachshund::dachshund::id_types::NodeId;
+use lib_dachshund::dachshund::simple_undirected_graph::SimpleUndirectedGraph;
+use lib_dachshund::dachshund::simple_undirected_graph_builder::SimpleUndirectedGraphBuilder;
 use std::collections::HashSet;
 use test::Bencher;
 
-fn get_rows(transformer: &Transformer) -> Vec<EdgeRow> {
-    let mut raw = vec![
-        "0\t1\t2\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t1\t3\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t2\t3\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t1\t4\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t2\t4\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t3\t4\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t1\t5\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t1\t6\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t1\t7\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t5\t7\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t6\t7\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t1\t8\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t2\t8\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t3\t8\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t4\t8\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t1\t9\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t3\t9\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t3\t10\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t1\t11\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t5\t11\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t6\t11\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t1\t12\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t1\t13\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t4\t13\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t1\t14\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t2\t14\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t3\t14\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t4\t14\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t6\t17\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t7\t17\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t1\t18\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t2\t18\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t1\t20\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t2\t20\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t1\t22\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t2\t22\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t24\t26\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t25\t26\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t3\t28\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t24\t28\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t25\t28\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t3\t29\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t24\t30\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t27\t30\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t2\t31\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t9\t31\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t1\t32\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t25\t32\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t26\t32\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t29\t32\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t3\t33\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t9\t33\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t15\t33\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t16\t33\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t19\t33\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t21\t33\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t23\t33\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t24\t33\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t30\t33\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t31\t33\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t32\t33\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t9\t34\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t10\t34\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t14\t34\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t15\t34\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t16\t34\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t19\t34\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t20\t34\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t21\t34\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t23\t34\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t24\t34\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t27\t34\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t28\t34\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t29\t34\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t30\t34\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t31\t34\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t32\t34\tstudent\tis_friends_with\tstudent".to_string(),
-        "0\t33\t34\tstudent\tis_friends_with\tstudent".to_string(),
-    ];
-    let mut reversed: Vec<String> = Vec::new();
-    for el in &raw {
-        let mut vec: Vec<&str> = el.split('\t').collect();
-        vec.swap(1, 2);
-        reversed.push(vec.join("\t"));
-    }
-    for el in &reversed {
-        raw.push(el.to_string());
-    }
-    assert_eq!(raw.len(), 78 * 2);
-    let rows: Vec<EdgeRow> = process_raw_vector(&transformer, raw).unwrap();
-    rows
+fn get_karate_club_edges() -> Vec<(usize, usize)> {
+    vec![
+        (1, 2),
+        (1, 3),
+        (2, 3),
+        (1, 4),
+        (2, 4),
+        (3, 4),
+        (1, 5),
+        (1, 6),
+        (1, 7),
+        (5, 7),
+        (6, 7),
+        (1, 8),
+        (2, 8),
+        (3, 8),
+        (4, 8),
+        (1, 9),
+        (3, 9),
+        (3, 10),
+        (1, 11),
+        (5, 11),
+        (6, 11),
+        (1, 12),
+        (1, 13),
+        (4, 13),
+        (1, 14),
+        (2, 14),
+        (3, 14),
+        (4, 14),
+        (6, 17),
+        (7, 17),
+        (1, 18),
+        (2, 18),
+        (1, 20),
+        (2, 20),
+        (1, 22),
+        (2, 22),
+        (24, 26),
+        (25, 26),
+        (3, 28),
+        (24, 28),
+        (25, 28),
+        (3, 29),
+        (24, 30),
+        (27, 30),
+        (2, 31),
+        (9, 31),
+        (1, 32),
+        (25, 32),
+        (26, 32),
+        (29, 32),
+        (3, 33),
+        (9, 33),
+        (15, 33),
+        (16, 33),
+        (19, 33),
+        (21, 33),
+        (23, 33),
+        (24, 33),
+        (30, 33),
+        (31, 33),
+        (32, 33),
+        (9, 34),
+        (10, 34),
+        (14, 34),
+        (15, 34),
+        (16, 34),
+        (19, 34),
+        (20, 34),
+        (21, 34),
+        (23, 34),
+        (24, 34),
+        (27, 34),
+        (28, 34),
+        (29, 34),
+        (30, 34),
+        (31, 34),
+        (32, 34),
+        (33, 34),
+    ]
 }
-
-fn get_transformer() -> Transformer {
-    let typespec: Vec<Vec<String>> = vec![vec![
-        "student".to_string(),
-        "is_friends_with".into(),
-        "student".into(),
-    ]];
-    gen_test_transformer(typespec, "student".to_string()).unwrap()
-}
-
 fn get_karate_club_graph_with_one_extra_edge() -> SimpleUndirectedGraph {
-    let graph_id: GraphId = 0.into();
-    let transformer = get_transformer();
-    let mut rows: Vec<EdgeRow> = get_rows(&transformer);
-    let source = NodeId::from(35 as i64);
-    let target = NodeId::from(36 as i64);
-    let new_edge = EdgeRow {
-        graph_id: rows[0].graph_id,
-        source_id: source,
-        target_id: target,
-        source_type_id: rows[0].source_type_id,
-        target_type_id: rows[0].target_type_id,
-        edge_type_id: rows[0].edge_type_id,
-    };
-    let rev_edge = EdgeRow {
-        graph_id: rows[0].graph_id,
-        source_id: target,
-        target_id: source,
-        source_type_id: rows[0].source_type_id,
-        target_type_id: rows[0].target_type_id,
-        edge_type_id: rows[0].edge_type_id,
-    };
-    rows.push(new_edge);
-    rows.push(rev_edge);
-    let graph: SimpleUndirectedGraph = transformer
-        .build_pruned_graph::<SimpleUndirectedGraphBuilder, SimpleUndirectedGraph>(graph_id, &rows)
-        .unwrap();
-    graph
+    let mut rows = get_karate_club_edges();
+    rows.push((35, 36));
+    SimpleUndirectedGraphBuilder::from_vector(
+        &rows.into_iter().map(|(x, y)| (x as i64, y as i64)).collect(),
+    )
 }
 
-fn get_two_karate_clubs_edges(transformer: &Transformer) -> Vec<EdgeRow> {
-    let mut rows: Vec<EdgeRow> = get_rows(&transformer);
-    for i in 1..rows.len() {
-        let new_edge = EdgeRow {
-            graph_id: rows[i].graph_id,
-            source_id: NodeId::from(rows[i].source_id.value() + 35),
-            target_id: NodeId::from(rows[i].target_id.value() + 35),
-            source_type_id: rows[0].source_type_id,
-            target_type_id: rows[0].target_type_id,
-            edge_type_id: rows[0].edge_type_id,
-        };
-        rows.push(new_edge);
+fn get_two_karate_clubs_edges() -> Vec<(usize, usize)> {
+    let mut rows = get_karate_club_edges();
+    for (i, j) in get_karate_club_edges() {
+        rows.push((i + 35, j + 35));
     }
     rows
 }
 
 fn get_two_karate_clubs() -> SimpleUndirectedGraph {
-    let graph_id: GraphId = 0.into();
-    let transformer = get_transformer();
-    let rows = get_two_karate_clubs_edges(&transformer);
-    let graph: SimpleUndirectedGraph = transformer
-        .build_pruned_graph::<SimpleUndirectedGraphBuilder, SimpleUndirectedGraph>(graph_id, &rows)
-        .unwrap();
-    return graph;
+    let rows = get_two_karate_clubs_edges();
+    SimpleUndirectedGraphBuilder::from_vector(
+        &rows.into_iter().map(|(x, y)| (x as i64, y as i64)).collect(),
+    )
 }
 
 fn get_two_karate_clubs_with_bridge() -> SimpleUndirectedGraph {
-    let graph_id: GraphId = 0.into();
-    let transformer = get_transformer();
-    let mut rows = get_two_karate_clubs_edges(&transformer);
-    let source = NodeId::from(34 as i64);
-    let target = NodeId::from(35 as i64);
-    let new_edge = EdgeRow {
-        graph_id: rows[0].graph_id,
-        source_id: source,
-        target_id: target,
-        source_type_id: rows[0].source_type_id,
-        target_type_id: rows[0].target_type_id,
-        edge_type_id: rows[0].edge_type_id,
-    };
-    let rev_edge = EdgeRow {
-        graph_id: rows[0].graph_id,
-        source_id: target,
-        target_id: source,
-        source_type_id: rows[0].source_type_id,
-        target_type_id: rows[0].target_type_id,
-        edge_type_id: rows[0].edge_type_id,
-    };
-    rows.push(new_edge);
-    rows.push(rev_edge);
-    let graph: SimpleUndirectedGraph = transformer
-        .build_pruned_graph::<SimpleUndirectedGraphBuilder, SimpleUndirectedGraph>(graph_id, &rows)
-        .unwrap();
-    graph
+    let mut rows = get_two_karate_clubs_edges();
+    rows.push((34, 35));
+    SimpleUndirectedGraphBuilder::from_vector(
+        &rows.into_iter().map(|(x, y)| (x as i64, y as i64)).collect(),
+    )
 }
 fn get_karate_club_graph() -> SimpleUndirectedGraph {
-    let graph_id: GraphId = 0.into();
-    let transformer = get_transformer();
-    let rows: Vec<EdgeRow> = get_rows(&transformer);
-    let graph: SimpleUndirectedGraph = transformer
-        .build_pruned_graph::<SimpleUndirectedGraphBuilder, SimpleUndirectedGraph>(graph_id, &rows)
-        .unwrap();
-    graph
+    let rows = get_karate_club_edges();
+    SimpleUndirectedGraphBuilder::from_vector(
+        &rows.into_iter().map(|(x, y)| (x as i64, y as i64)).collect(),
+    )
 }
 
 #[cfg(test)]

--- a/tests/karate_club.rs
+++ b/tests/karate_club.rs
@@ -10,23 +10,17 @@ extern crate lib_dachshund;
 extern crate test;
 use lib_dachshund::dachshund::algorithms::adjacency_matrix::AdjacencyMatrix;
 use lib_dachshund::dachshund::algorithms::algebraic_connectivity::AlgebraicConnectivity;
-use lib_dachshund::dachshund::algorithms::connected_components::ConnectedComponents;
-use lib_dachshund::dachshund::algorithms::coreness::Coreness;
 use lib_dachshund::dachshund::algorithms::betweenness::Betweenness;
 use lib_dachshund::dachshund::algorithms::clustering::Clustering;
 use lib_dachshund::dachshund::algorithms::cnm_communities::CNMCommunities;
+use lib_dachshund::dachshund::algorithms::connected_components::ConnectedComponents;
 use lib_dachshund::dachshund::algorithms::connectivity::Connectivity;
+use lib_dachshund::dachshund::algorithms::coreness::Coreness;
 use lib_dachshund::dachshund::algorithms::eigenvector_centrality::EigenvectorCentrality;
-use lib_dachshund::dachshund::graph_base::GraphBase;
-use lib_dachshund::dachshund::id_types::{GraphId, NodeId};
 use lib_dachshund::dachshund::algorithms::laplacian::Laplacian;
-use lib_dachshund::dachshund::row::EdgeRow;
 use lib_dachshund::dachshund::algorithms::shortest_paths::ShortestPaths;
-use lib_dachshund::dachshund::simple_undirected_graph::SimpleUndirectedGraph;
-use lib_dachshund::dachshund::simple_undirected_graph_builder::SimpleUndirectedGraphBuilder;
 use lib_dachshund::dachshund::algorithms::transitivity::Transitivity;
-use lib_dachshund::dachshund::test_utils::{gen_test_transformer, process_raw_vector};
-use lib_dachshund::dachshund::transformer::Transformer;
+use lib_dachshund::dachshund::graph_base::GraphBase;
 use lib_dachshund::dachshund::id_types::NodeId;
 use lib_dachshund::dachshund::simple_undirected_graph::SimpleUndirectedGraph;
 use lib_dachshund::dachshund::simple_undirected_graph_builder::SimpleUndirectedGraphBuilder;
@@ -119,7 +113,10 @@ fn get_karate_club_graph_with_one_extra_edge() -> SimpleUndirectedGraph {
     let mut rows = get_karate_club_edges();
     rows.push((35, 36));
     SimpleUndirectedGraphBuilder::from_vector(
-        &rows.into_iter().map(|(x, y)| (x as i64, y as i64)).collect(),
+        &rows
+            .into_iter()
+            .map(|(x, y)| (x as i64, y as i64))
+            .collect(),
     )
 }
 
@@ -134,7 +131,10 @@ fn get_two_karate_clubs_edges() -> Vec<(usize, usize)> {
 fn get_two_karate_clubs() -> SimpleUndirectedGraph {
     let rows = get_two_karate_clubs_edges();
     SimpleUndirectedGraphBuilder::from_vector(
-        &rows.into_iter().map(|(x, y)| (x as i64, y as i64)).collect(),
+        &rows
+            .into_iter()
+            .map(|(x, y)| (x as i64, y as i64))
+            .collect(),
     )
 }
 
@@ -142,13 +142,19 @@ fn get_two_karate_clubs_with_bridge() -> SimpleUndirectedGraph {
     let mut rows = get_two_karate_clubs_edges();
     rows.push((34, 35));
     SimpleUndirectedGraphBuilder::from_vector(
-        &rows.into_iter().map(|(x, y)| (x as i64, y as i64)).collect(),
+        &rows
+            .into_iter()
+            .map(|(x, y)| (x as i64, y as i64))
+            .collect(),
     )
 }
 fn get_karate_club_graph() -> SimpleUndirectedGraph {
     let rows = get_karate_club_edges();
     SimpleUndirectedGraphBuilder::from_vector(
-        &rows.into_iter().map(|(x, y)| (x as i64, y as i64)).collect(),
+        &rows
+            .into_iter()
+            .map(|(x, y)| (x as i64, y as i64))
+            .collect(),
     )
 }
 

--- a/tests/simple_graph.rs
+++ b/tests/simple_graph.rs
@@ -6,9 +6,9 @@
  */
 extern crate lib_dachshund;
 use crate::lib_dachshund::TransformerBase;
+use lib_dachshund::dachshund::algorithms::cnm_communities::CNMCommunities;
 use lib_dachshund::dachshund::algorithms::connected_components::ConnectedComponents;
 use lib_dachshund::dachshund::algorithms::coreness::Coreness;
-use lib_dachshund::dachshund::algorithms::cnm_communities::CNMCommunities;
 use lib_dachshund::dachshund::id_types::NodeId;
 use lib_dachshund::dachshund::input::Input;
 use lib_dachshund::dachshund::output::Output;

--- a/tests/triangles.rs
+++ b/tests/triangles.rs
@@ -10,10 +10,10 @@ extern crate lib_dachshund;
 extern crate test;
 
 use lib_dachshund::dachshund::algorithms::clustering::Clustering;
+use lib_dachshund::dachshund::algorithms::transitivity::Transitivity;
 use lib_dachshund::dachshund::id_types::NodeId;
 use lib_dachshund::dachshund::simple_undirected_graph::SimpleUndirectedGraph;
 use lib_dachshund::dachshund::simple_undirected_graph_builder::SimpleUndirectedGraphBuilder;
-use lib_dachshund::dachshund::algorithms::transitivity::Transitivity;
 
 use test::Bencher;
 


### PR DESCRIPTION
This further enforces the separation between `SimpleUndirectedGraph` and `TypedGraph`. Doing so allows us to contemplate specifying a `SimpleDirectedGraph` as a next step from `SimpleUndirectedGraph`.

I removed the implementation of `GraphBuilder` by `SimpleUndirectedGraphBuilder`. `GraphBuilder` needs to be thoroughly rewritten, as it is quite crufty at this point.