### PR TITLE
Added SimpleUndirectedGraphBuilderWithCliques / graph builder functions now attach to object

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,9 @@ version = "2.0.0"
 [dependencies.fxhash]
 version = "0.2.1"
 
+[dependencies.itertools]
+version = "0.9.0"
+
 [[bin]]
 name = "clique_miner"
 path = "src/clique_miner.rs"

--- a/src/dachshund/graph_builder_base.rs
+++ b/src/dachshund/graph_builder_base.rs
@@ -12,5 +12,5 @@ where
 {
     type GraphType;
 
-    fn from_vector(data: &Vec<(i64, i64)>) -> Self::GraphType;
+    fn from_vector(&self, data: &Vec<(i64, i64)>) -> Self::GraphType;
 }

--- a/src/dachshund/simple_directed_graph_builder.rs
+++ b/src/dachshund/simple_directed_graph_builder.rs
@@ -20,8 +20,7 @@ impl GraphBuilderBase for SimpleDirectedGraphBuilder {
     type GraphType = SimpleDirectedGraph;
 
     // builds a graph from a vector of IDs. Repeated edges are ignored.
-    #[allow(clippy::ptr_arg)]
-    fn from_vector(data: &Vec<(i64, i64)>) -> SimpleDirectedGraph {
+    fn from_vector(&self, data: &Vec<(i64, i64)>) -> SimpleDirectedGraph {
         let mut ids: BTreeMap<NodeId, (BTreeSet<NodeId>, BTreeSet<NodeId>)> = BTreeMap::new();
         for (id1, id2) in data {
             ids.entry(NodeId::from(*id1))

--- a/src/dachshund/simple_transformer.rs
+++ b/src/dachshund/simple_transformer.rs
@@ -128,7 +128,8 @@ impl TransformerBase for SimpleTransformer {
         output: &Sender<(Option<String>, bool)>,
     ) -> CLQResult<()> {
         let tuples: Vec<(i64, i64)> = self.batch.iter().map(|x| x.as_tuple()).collect();
-        let graph = SimpleUndirectedGraphBuilder::from_vector(&tuples);
+        let builder = SimpleUndirectedGraphBuilder {};
+        let graph = builder.from_vector(&tuples);
         let stats = Self::compute_graph_stats_json(&graph);
         let original_id = self
             .line_processor
@@ -159,7 +160,8 @@ impl TransformerBase for SimpleParallelTransformer {
         let output_clone = output.clone();
         let line_processor = self.line_processor.clone();
         self.pool.spawn(move || {
-            let graph = SimpleUndirectedGraphBuilder::from_vector(&tuples);
+            let builder = SimpleUndirectedGraphBuilder {};
+            let graph = builder.from_vector(&tuples);
             let stats = Self::compute_graph_stats_json(&graph);
             let original_id = line_processor.get_original_id(graph_id.value() as usize);
             let line: String = format!("{}\t{}", original_id, stats);

--- a/src/dachshund/simple_undirected_graph_builder.rs
+++ b/src/dachshund/simple_undirected_graph_builder.rs
@@ -11,48 +11,44 @@ use crate::dachshund::simple_undirected_graph::SimpleUndirectedGraph;
 use std::collections::{BTreeMap, BTreeSet};
 extern crate fxhash;
 use fxhash::FxHashMap;
+use itertools::Itertools;
 
 use rand::prelude::*;
 pub struct SimpleUndirectedGraphBuilder {}
-impl SimpleUndirectedGraphBuilder {
+
+pub trait TSimpleUndirectedGraphBuilder: GraphBuilderBase {
     // Build a graph with n vertices with every possible edge.
-    pub fn get_complete_graph(n: u64) -> SimpleUndirectedGraph {
+    fn get_complete_graph(&self, n: u64) -> Self::GraphType {
         let mut v = Vec::new();
         for i in 1..n {
             for j in i + 1..=n {
                 v.push((i, j));
             }
         }
-        SimpleUndirectedGraphBuilder::from_vector(
-            &v.into_iter().map(|(x, y)| (x as i64, y as i64)).collect(),
-        )
+        self.from_vector(&v.into_iter().map(|(x, y)| (x as i64, y as i64)).collect())
     }
 
     // Build a graph with a sequence of n vertices with an edge between
     // each pair of successive vertices.
-    pub fn get_path_graph(n: u64) -> SimpleUndirectedGraph {
+    fn get_path_graph(&self, n: u64) -> Self::GraphType {
         let mut v = Vec::new();
         for i in 0..n {
             v.push((i, (i + 1)));
         }
 
-        SimpleUndirectedGraphBuilder::from_vector(
-            &v.into_iter().map(|(x, y)| (x as i64, y as i64)).collect(),
-        )
+        self.from_vector(&v.into_iter().map(|(x, y)| (x as i64, y as i64)).collect())
     }
 
     // Build a graph with a sequence of n vertices with an edge between
     // each pair of successive vertices, plus an edge between the first and
     // last vertices.
-    pub fn get_cycle_graph(n: u64) -> SimpleUndirectedGraph {
+    fn get_cycle_graph(&self, n: u64) -> Self::GraphType {
         let mut v = Vec::new();
         for i in 0..n {
             v.push((i, (i + 1) % n));
         }
 
-        SimpleUndirectedGraphBuilder::from_vector(
-            &v.into_iter().map(|(x, y)| (x as i64, y as i64)).collect(),
-        )
+        self.from_vector(&v.into_iter().map(|(x, y)| (x as i64, y as i64)).collect())
     }
 
     // Builds an Erdos-Renyi graph on n edges with p vertices.
@@ -60,7 +56,7 @@ impl SimpleUndirectedGraphBuilder {
     //  probability p.)
     // [TODO] Switch to the faster implementation using geometric distributions
     // for sparse graphs.
-    pub fn get_er_graph(n: u64, p: f64) -> SimpleUndirectedGraph {
+    fn get_er_graph(&self, n: u64, p: f64) -> Self::GraphType {
         let mut v = Vec::new();
         let mut rng = rand::thread_rng();
 
@@ -72,18 +68,10 @@ impl SimpleUndirectedGraphBuilder {
             }
         }
 
-        SimpleUndirectedGraphBuilder::from_vector(
-            &v.into_iter().map(|(x, y)| (x as i64, y as i64)).collect(),
-        )
+        self.from_vector(&v.into_iter().map(|(x, y)| (x as i64, y as i64)).collect())
     }
-}
-impl GraphBuilderBase for SimpleUndirectedGraphBuilder {
-    type GraphType = SimpleUndirectedGraph;
 
-    // builds a graph from a vector of IDs. Repeated edges are ignored.
-    // Edges only need to be provided once (this being an undirected graph)
-    #[allow(clippy::ptr_arg)]
-    fn from_vector(data: &Vec<(i64, i64)>) -> SimpleUndirectedGraph {
+    fn get_node_ids(data: &Vec<(i64, i64)>) -> BTreeMap<NodeId, BTreeSet<NodeId>> {
         let mut ids: BTreeMap<NodeId, BTreeSet<NodeId>> = BTreeMap::new();
         for (id1, id2) in data {
             ids.entry(NodeId::from(*id1))
@@ -93,6 +81,9 @@ impl GraphBuilderBase for SimpleUndirectedGraphBuilder {
                 .or_insert_with(BTreeSet::new)
                 .insert(NodeId::from(*id1));
         }
+        ids
+    }
+    fn get_nodes(ids: BTreeMap<NodeId, BTreeSet<NodeId>>) -> FxHashMap<NodeId, SimpleNode> {
         let mut nodes: FxHashMap<NodeId, SimpleNode> = FxHashMap::default();
         for (id, neighbors) in ids.into_iter() {
             nodes.insert(
@@ -102,6 +93,54 @@ impl GraphBuilderBase for SimpleUndirectedGraphBuilder {
                     neighbors: neighbors,
                 },
             );
+        }
+        nodes
+    }
+}
+
+impl GraphBuilderBase for SimpleUndirectedGraphBuilder {
+    type GraphType = SimpleUndirectedGraph;
+
+    // builds a graph from a vector of IDs. Repeated edges are ignored.
+    // Edges only need to be provided once (this being an undirected graph)
+    fn from_vector(&self, data: &Vec<(i64, i64)>) -> SimpleUndirectedGraph {
+        let ids = Self::get_node_ids(data);
+        let nodes = Self::get_nodes(ids);
+        SimpleUndirectedGraph {
+            ids: nodes.keys().cloned().collect(),
+            nodes,
+        }
+    }
+}
+impl TSimpleUndirectedGraphBuilder for SimpleUndirectedGraphBuilder {}
+
+pub struct SimpleUndirectedGraphBuilderWithCliques {
+    cliques: Vec<BTreeSet<NodeId>>,
+}
+
+impl SimpleUndirectedGraphBuilderWithCliques {
+    pub fn new(cliques: Vec<BTreeSet<NodeId>>) -> Self {
+        Self { cliques }
+    }
+}
+impl TSimpleUndirectedGraphBuilder for SimpleUndirectedGraphBuilderWithCliques {}
+impl GraphBuilderBase for SimpleUndirectedGraphBuilderWithCliques {
+    type GraphType = SimpleUndirectedGraph;
+
+    // builds a graph from a vector of IDs. Repeated edges are ignored.
+    // Edges only need to be provided once (this being an undirected graph)
+    fn from_vector(&self, data: &Vec<(i64, i64)>) -> SimpleUndirectedGraph {
+        let ids = Self::get_node_ids(data);
+        let mut nodes = Self::get_nodes(ids);
+        for clique in &self.cliques {
+            for comb in clique.iter().combinations(2) {
+                let id1 = comb.get(0).unwrap().clone();
+                let id2 = comb.get(1).unwrap().clone();
+                let node = nodes.get_mut(id1).unwrap();
+                node.neighbors.insert(*id2);
+                let node = nodes.get_mut(id2).unwrap();
+                node.neighbors.insert(*id1);
+            }
         }
         SimpleUndirectedGraph {
             ids: nodes.keys().cloned().collect(),

--- a/tests/cnm.rs
+++ b/tests/cnm.rs
@@ -27,9 +27,8 @@ fn get_graph(idx: usize) -> Result<SimpleUndirectedGraph, String> {
         ],
         _ => return Err("Invalid index".to_string()),
     };
-    Ok(SimpleUndirectedGraphBuilder::from_vector(
-        &v.into_iter().map(|(x, y)| (x as i64, y as i64)).collect(),
-    ))
+    Ok(SimpleUndirectedGraphBuilder {}
+        .from_vector(&v.into_iter().map(|(x, y)| (x as i64, y as i64)).collect()))
 }
 fn get_expected_modularity_changes(idx: usize) -> Result<Vec<f64>, String> {
     match idx {

--- a/tests/karate_club.rs
+++ b/tests/karate_club.rs
@@ -32,8 +32,10 @@ use lib_dachshund::dachshund::node::DirectedNodeBase;
 use lib_dachshund::dachshund::simple_directed_graph::{DirectedGraph, SimpleDirectedGraph};
 use lib_dachshund::dachshund::simple_directed_graph_builder::SimpleDirectedGraphBuilder;
 use lib_dachshund::dachshund::simple_undirected_graph::SimpleUndirectedGraph;
-use lib_dachshund::dachshund::simple_undirected_graph_builder::SimpleUndirectedGraphBuilder;
-use std::collections::{HashMap, HashSet};
+use lib_dachshund::dachshund::simple_undirected_graph_builder::{
+    SimpleUndirectedGraphBuilder, SimpleUndirectedGraphBuilderWithCliques,
+};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use test::Bencher;
 
 fn get_karate_club_edges() -> Vec<(usize, usize)> {
@@ -118,14 +120,14 @@ fn get_karate_club_edges() -> Vec<(usize, usize)> {
         (33, 34),
     ]
 }
-fn _get_karate_club_graph_with_one_extra_edge<T, R>() -> R
+fn _get_karate_club_graph_with_one_extra_edge<T, R>(builder: T) -> R
 where
     R: GraphBase,
     T: GraphBuilderBase<GraphType = R>,
 {
     let mut rows = get_karate_club_edges();
     rows.push((35, 36));
-    T::from_vector(
+    builder.from_vector(
         &rows
             .into_iter()
             .map(|(x, y)| (x as i64, y as i64))
@@ -133,10 +135,12 @@ where
     )
 }
 fn get_karate_club_graph_with_one_extra_edge() -> SimpleUndirectedGraph {
-    _get_karate_club_graph_with_one_extra_edge::<SimpleUndirectedGraphBuilder, _>()
+    let builder = SimpleUndirectedGraphBuilder {};
+    _get_karate_club_graph_with_one_extra_edge::<SimpleUndirectedGraphBuilder, _>(builder)
 }
 fn get_directed_karate_club_graph_with_one_extra_edge() -> SimpleDirectedGraph {
-    _get_karate_club_graph_with_one_extra_edge::<SimpleDirectedGraphBuilder, _>()
+    let builder = SimpleDirectedGraphBuilder {};
+    _get_karate_club_graph_with_one_extra_edge::<SimpleDirectedGraphBuilder, _>(builder)
 }
 
 fn get_two_karate_clubs_edges() -> Vec<(usize, usize)> {
@@ -147,13 +151,13 @@ fn get_two_karate_clubs_edges() -> Vec<(usize, usize)> {
     rows
 }
 
-fn _get_two_karate_clubs<T, R>() -> R
+fn _get_two_karate_clubs<T, R>(builder: T) -> R
 where
     R: GraphBase,
     T: GraphBuilderBase<GraphType = R>,
 {
     let rows = get_two_karate_clubs_edges();
-    T::from_vector(
+    builder.from_vector(
         &rows
             .into_iter()
             .map(|(x, y)| (x as i64, y as i64))
@@ -161,11 +165,13 @@ where
     )
 }
 fn get_two_karate_clubs() -> SimpleUndirectedGraph {
-    _get_two_karate_clubs::<SimpleUndirectedGraphBuilder, _>()
+    let builder = SimpleUndirectedGraphBuilder {};
+    _get_two_karate_clubs::<SimpleUndirectedGraphBuilder, _>(builder)
 }
 fn get_directed_karate_club_graph_both_ways() -> SimpleDirectedGraph {
     let rows = get_karate_club_edges();
-    let graph = SimpleDirectedGraphBuilder::from_vector(
+    let builder = SimpleDirectedGraphBuilder {};
+    let graph = builder.from_vector(
         &rows
             .iter()
             .cloned()
@@ -180,7 +186,8 @@ fn get_directed_karate_club_graph_both_ways() -> SimpleDirectedGraph {
 }
 fn get_directed_karate_club_graph_with_core(core: HashSet<usize>) -> SimpleDirectedGraph {
     let rows = get_karate_club_edges();
-    let graph = SimpleDirectedGraphBuilder::from_vector(
+    let builder = SimpleDirectedGraphBuilder {};
+    let graph = builder.from_vector(
         &rows
             .iter()
             .cloned()
@@ -196,14 +203,14 @@ fn get_directed_karate_club_graph_with_core(core: HashSet<usize>) -> SimpleDirec
     graph
 }
 
-fn _get_two_karate_clubs_with_bridge<T, R>() -> R
+fn _get_two_karate_clubs_with_bridge<T, R>(builder: T) -> R
 where
     R: GraphBase,
     T: GraphBuilderBase<GraphType = R>,
 {
     let mut rows = get_two_karate_clubs_edges();
     rows.push((34, 35));
-    T::from_vector(
+    builder.from_vector(
         &rows
             .into_iter()
             .map(|(x, y)| (x as i64, y as i64))
@@ -211,16 +218,17 @@ where
     )
 }
 fn get_two_karate_clubs_with_bridge() -> SimpleUndirectedGraph {
-    _get_two_karate_clubs_with_bridge::<SimpleUndirectedGraphBuilder, _>()
+    let builder = SimpleUndirectedGraphBuilder {};
+    _get_two_karate_clubs_with_bridge::<SimpleUndirectedGraphBuilder, _>(builder)
 }
 
-fn _get_karate_club_graph<T, R>() -> R
+fn _get_karate_club_graph<T, R>(builder: T) -> R
 where
     R: GraphBase,
     T: GraphBuilderBase<GraphType = R>,
 {
     let rows = get_karate_club_edges();
-    T::from_vector(
+    builder.from_vector(
         &rows
             .into_iter()
             .map(|(x, y)| (x as i64, y as i64))
@@ -228,10 +236,16 @@ where
     )
 }
 fn get_karate_club_graph() -> SimpleUndirectedGraph {
-    _get_karate_club_graph::<SimpleUndirectedGraphBuilder, _>()
+    let builder = SimpleUndirectedGraphBuilder {};
+    _get_karate_club_graph::<SimpleUndirectedGraphBuilder, _>(builder)
 }
 fn get_directed_karate_club_graph() -> SimpleDirectedGraph {
-    _get_karate_club_graph::<SimpleDirectedGraphBuilder, _>()
+    let builder = SimpleDirectedGraphBuilder {};
+    _get_karate_club_graph::<SimpleDirectedGraphBuilder, _>(builder)
+}
+fn get_karate_club_graph_with_cliques(cliques: Vec<BTreeSet<NodeId>>) -> SimpleUndirectedGraph {
+    let builder = SimpleUndirectedGraphBuilderWithCliques::new(cliques);
+    _get_karate_club_graph::<SimpleUndirectedGraphBuilderWithCliques, _>(builder)
 }
 
 #[cfg(test)]
@@ -672,4 +686,32 @@ fn test_acyclic_directed() {
     let graph_with_core =
         get_directed_karate_club_graph_with_core(core.into_iter().collect::<HashSet<usize>>());
     assert!(!graph_with_core.is_acyclic());
+}
+
+#[test]
+fn test_clique_seeding() {
+    let clique = vec![1, 2, 3, 4, 5];
+    let cliques = vec![clique
+        .into_iter()
+        .map(|x| NodeId::from(x))
+        .collect::<BTreeSet<_>>()];
+    let g = get_karate_club_graph_with_cliques(cliques);
+    // adding 3 edges, from 2 -> 5, 3, -> 5, 4 -> 5
+    assert_eq!(g.count_edges(), 81);
+
+    let clique1 = vec![1, 2, 3, 4, 5];
+    let clique2 = vec![5, 6, 7];
+    let cliques = vec![
+        clique1
+            .into_iter()
+            .map(|x| NodeId::from(x))
+            .collect::<BTreeSet<_>>(),
+        clique2
+            .into_iter()
+            .map(|x| NodeId::from(x))
+            .collect::<BTreeSet<_>>(),
+    ];
+    let g = get_karate_club_graph_with_cliques(cliques);
+    // adding 5 edges, from 2 -> 5, 3, -> 5, 4 -> 5, 5 -> 6
+    assert_eq!(g.count_edges(), 82);
 }

--- a/tests/simple_directed_graph.rs
+++ b/tests/simple_directed_graph.rs
@@ -126,7 +126,7 @@ fn get_rows(idx: usize) -> Result<Vec<(usize, usize)>, String> {
 }
 
 fn get_graph(idx: usize) -> Result<SimpleDirectedGraph, String> {
-    Ok(SimpleDirectedGraphBuilder::from_vector(
+    Ok(SimpleDirectedGraphBuilder {}.from_vector(
         &get_rows(idx)?
             .into_iter()
             .map(|(x, y)| (x as i64, y as i64))

--- a/tests/simple_graph.rs
+++ b/tests/simple_graph.rs
@@ -136,9 +136,8 @@ fn get_graph(idx: usize) -> Result<SimpleUndirectedGraph, String> {
         ],
         _ => return Err("Invalid index".to_string()),
     };
-    Ok(SimpleUndirectedGraphBuilder::from_vector(
-        &v.into_iter().map(|(x, y)| (x as i64, y as i64)).collect(),
-    ))
+    Ok(SimpleUndirectedGraphBuilder {}
+        .from_vector(&v.into_iter().map(|(x, y)| (x as i64, y as i64)).collect()))
 }
 fn get_expected_modularity_changes(idx: usize) -> Result<Vec<f64>, String> {
     match idx {

--- a/tests/triangles.rs
+++ b/tests/triangles.rs
@@ -14,7 +14,9 @@ use lib_dachshund::dachshund::algorithms::transitivity::Transitivity;
 use lib_dachshund::dachshund::graph_builder_base::GraphBuilderBase;
 use lib_dachshund::dachshund::id_types::NodeId;
 use lib_dachshund::dachshund::simple_undirected_graph::SimpleUndirectedGraph;
-use lib_dachshund::dachshund::simple_undirected_graph_builder::SimpleUndirectedGraphBuilder;
+use lib_dachshund::dachshund::simple_undirected_graph_builder::{
+    SimpleUndirectedGraphBuilder, TSimpleUndirectedGraphBuilder,
+};
 
 use test::Bencher;
 
@@ -22,14 +24,13 @@ use test::Bencher;
 // This is the minimal counterexample where T(G) != C(G).
 fn get_almost_k4_graph() -> SimpleUndirectedGraph {
     let v = vec![(0, 1), (0, 2), (0, 3), (1, 2), (1, 3)];
-    SimpleUndirectedGraphBuilder::from_vector(
-        &v.into_iter().map(|(x, y)| (x as i64, y as i64)).collect(),
-    )
+    SimpleUndirectedGraphBuilder {}
+        .from_vector(&v.into_iter().map(|(x, y)| (x as i64, y as i64)).collect())
 }
 
 #[test]
 fn test_triangle_count() {
-    let k4 = SimpleUndirectedGraphBuilder::get_complete_graph(4);
+    let k4 = SimpleUndirectedGraphBuilder {}.get_complete_graph(4);
     for node_id in k4.nodes.keys() {
         assert_eq!(3, k4.triangle_count(*node_id));
     }
@@ -43,7 +44,7 @@ fn test_triangle_count() {
 
 #[bench]
 fn bench_triangle_count(b: &mut Bencher) {
-    let k100 = SimpleUndirectedGraphBuilder::get_complete_graph(100);
+    let k100 = SimpleUndirectedGraphBuilder {}.get_complete_graph(100);
     b.iter(|| {
         for node_id in k100.nodes.keys() {
             k100.triangle_count(*node_id);
@@ -53,7 +54,7 @@ fn bench_triangle_count(b: &mut Bencher) {
 
 #[test]
 fn test_clustering_coefficient() {
-    let k4 = &SimpleUndirectedGraphBuilder::get_complete_graph(4);
+    let k4 = &SimpleUndirectedGraphBuilder {}.get_complete_graph(4);
     for node_id in k4.nodes.keys() {
         assert_eq!(1.0, k4.get_clustering_coefficient(*node_id).unwrap());
     }
@@ -66,7 +67,7 @@ fn test_clustering_coefficient() {
 
 #[test]
 fn test_transitivity() {
-    let k4 = &SimpleUndirectedGraphBuilder::get_complete_graph(4);
+    let k4 = &SimpleUndirectedGraphBuilder {}.get_complete_graph(4);
     assert_eq!(1.0, k4.get_transitivity());
 
     let almost_k4 = &get_almost_k4_graph();
@@ -75,7 +76,7 @@ fn test_transitivity() {
 
 #[test]
 fn test_approx_avg_clustering() {
-    let k4 = &SimpleUndirectedGraphBuilder::get_complete_graph(4);
+    let k4 = &SimpleUndirectedGraphBuilder {}.get_complete_graph(4);
     assert_eq!(1.0, k4.get_approx_avg_clustering(10));
 
     let almost_k4 = &get_almost_k4_graph();
@@ -85,7 +86,7 @@ fn test_approx_avg_clustering() {
 
 #[test]
 fn test_approx_transitivity() {
-    let k4 = &SimpleUndirectedGraphBuilder::get_complete_graph(4);
+    let k4 = &SimpleUndirectedGraphBuilder {}.get_complete_graph(4);
     assert_eq!(1.0, k4.get_approx_transitivity(10));
 
     let almost_k4 = &get_almost_k4_graph();


### PR DESCRIPTION
This PR sets up a new kind of builder for a simple undirected graph, one that also adds cliques to e.g. an Erdos-Renyi random graph -- this is the first example of a more sophisticated graph generation process. Doing so requires us to keep some state in the `GraphBuilder` struct. From now on graph builder functions attach to the GraphBuilder object -- those structs ceasing to be pure convenience-driven collections of functions.