### PR TITLE
TypedGraphBuilder now implements GraphBuilder trait

### DIFF
--- a/src/dachshund/graph_builder.rs
+++ b/src/dachshund/graph_builder.rs
@@ -22,7 +22,7 @@ where
     TGraph: Sized,
     TGraph: GraphBase<NodeType = Node>,
 {
-    fn _new(
+    fn create_graph(
         nodes: FxHashMap<NodeId, Node>,
         core_ids: Vec<NodeId>,
         non_core_ids: Vec<NodeId>,
@@ -117,7 +117,7 @@ where
         let mut node_map: FxHashMap<NodeId, Node> =
             Self::init_nodes(&source_ids_vec, &target_ids_vec, &target_type_ids);
         Self::populate_edges(rows, &mut node_map)?;
-        let mut graph = Self::_new(node_map, source_ids_vec, target_ids_vec)?;
+        let mut graph = Self::create_graph(node_map, source_ids_vec, target_ids_vec)?;
         if let Some(min_degree) = min_degree {
             graph = Self::prune(graph, rows, min_degree)?;
         }
@@ -137,7 +137,7 @@ where
         let mut filtered_node_map: FxHashMap<NodeId, Node> =
             Self::init_nodes(&filtered_source_ids, &filtered_target_ids, &target_type_ids);
         Self::populate_edges(&filtered_rows, &mut filtered_node_map)?;
-        Self::_new(filtered_node_map, filtered_source_ids, filtered_target_ids)
+        Self::create_graph(filtered_node_map, filtered_source_ids, filtered_target_ids)
     }
     /// called by `prune`, finds source and target nodes to exclude, as well as edges to exclude
     /// when rebuilding the graph from a filtered vector of `EdgeRows`.

--- a/src/dachshund/graph_builder.rs
+++ b/src/dachshund/graph_builder.rs
@@ -8,11 +8,10 @@ extern crate fxhash;
 extern crate nalgebra as na;
 use crate::dachshund::error::CLQResult;
 use crate::dachshund::graph_base::GraphBase;
-use crate::dachshund::id_types::{GraphId, NodeId, NodeTypeId};
-use crate::dachshund::node::{Node, NodeBase};
+use crate::dachshund::id_types::NodeId;
+use crate::dachshund::node::Node;
 use crate::dachshund::row::EdgeRow;
 use fxhash::FxHashMap;
-use std::collections::{HashMap, HashSet};
 
 /// Trait encapsulting the logic required to build a graph from a set of edge
 /// rows. Currently used to build typed graphs.
@@ -31,143 +30,5 @@ where
     /// given a set of initialized Nodes, populates the respective neighbors fields
     /// appropriately.
     fn populate_edges(rows: &[EdgeRow], node_map: &mut FxHashMap<NodeId, Node>) -> CLQResult<()>;
-
-    // initializes nodes in the graph with empty neighbors fields.
-    fn init_nodes(
-        core_ids: &[NodeId],
-        non_core_ids: &[NodeId],
-        non_core_type_ids: &HashMap<NodeId, NodeTypeId>,
-    ) -> FxHashMap<NodeId, Node> {
-        let mut node_map: FxHashMap<NodeId, Node> = FxHashMap::default();
-        for &id in core_ids {
-            let node = Node::new(
-                id,             // node_id,
-                true,           // is_core,
-                None,           // non_core_type,
-                Vec::new(),     // edges,
-                HashMap::new(), //neighbors
-            );
-            node_map.insert(id, node);
-        }
-        for &id in non_core_ids {
-            let node = Node::new(
-                id,                           // node_id,
-                false,                        // is_core,
-                Some(non_core_type_ids[&id]), // non_core_type,
-                Vec::new(),                   // edges,
-                HashMap::new(),               // neighbors
-            );
-            node_map.insert(id, node);
-        }
-        node_map
-    }
-
-    /// Trims edges greedily, until all edges in the graph have degree at least min_degree.
-    /// Note that this function does not delete any nodes -- just finds nodes to delete. It is
-    /// called by `prune`, which actually does the deletion.
-    fn trim_edges(node_map: &mut FxHashMap<NodeId, Node>, min_degree: &usize) -> HashSet<NodeId> {
-        let mut degree_map: HashMap<NodeId, usize> = HashMap::new();
-        for (node_id, node) in node_map.iter() {
-            let node_degree: usize = node.degree();
-            degree_map.insert(*node_id, node_degree);
-        }
-        let mut nodes_to_delete: HashSet<NodeId> = HashSet::new();
-        loop {
-            let mut nodes_to_update: HashSet<NodeId> = HashSet::new();
-            for (node_id, node_degree) in degree_map.iter() {
-                if node_degree < min_degree && !nodes_to_delete.contains(node_id) {
-                    nodes_to_update.insert(*node_id);
-                    nodes_to_delete.insert(*node_id);
-                }
-            }
-            if nodes_to_update.is_empty() {
-                break;
-            }
-            for node_id in nodes_to_update.iter() {
-                let node: &Node = &node_map[node_id];
-                for n in node.edges.iter() {
-                    let neighbor_node_id: NodeId = n.target_id;
-                    let current_degree: usize = degree_map[&neighbor_node_id];
-                    degree_map.insert(neighbor_node_id, current_degree - 1);
-                }
-            }
-        }
-        nodes_to_delete
-    }
-    /// creates a TGraph object from a vector of rows. Client must provide
-    /// graph_id which must match with each row's graph_id. If min_degree
-    /// is provided, the graph is additionally pruned.
-    fn new(graph_id: GraphId, rows: &[EdgeRow], min_degree: Option<usize>) -> CLQResult<TGraph> {
-        let mut source_ids: HashSet<NodeId> = HashSet::new();
-        let mut target_ids: HashSet<NodeId> = HashSet::new();
-        let mut target_type_ids: HashMap<NodeId, NodeTypeId> = HashMap::new();
-        for r in rows.iter() {
-            assert!(graph_id == r.graph_id);
-            source_ids.insert(r.source_id);
-            target_ids.insert(r.target_id);
-            target_type_ids.insert(r.target_id, r.target_type_id);
-        }
-
-        // warrant a canonical order on the id vectors
-        let mut source_ids_vec: Vec<NodeId> = source_ids.into_iter().collect();
-        source_ids_vec.sort();
-        let mut target_ids_vec: Vec<NodeId> = target_ids.into_iter().collect();
-        target_ids_vec.sort();
-
-        let mut node_map: FxHashMap<NodeId, Node> =
-            Self::init_nodes(&source_ids_vec, &target_ids_vec, &target_type_ids);
-        Self::populate_edges(rows, &mut node_map)?;
-        let mut graph = Self::create_graph(node_map, source_ids_vec, target_ids_vec)?;
-        if let Some(min_degree) = min_degree {
-            graph = Self::prune(graph, rows, min_degree)?;
-        }
-        Ok(graph)
-    }
-    /// Takes an already-built graph and the edge rows used to create it, returning a
-    /// new graph, where all nodes are assured to have degree at least min_degree.
-    /// The provision of a TGraph is necessary, since the notion of "degree" does
-    /// not make sense outside of a graph.
-    fn prune(graph: TGraph, rows: &[EdgeRow], min_degree: usize) -> CLQResult<TGraph> {
-        let mut target_type_ids: HashMap<NodeId, NodeTypeId> = HashMap::new();
-        for r in rows.iter() {
-            target_type_ids.insert(r.target_id, r.target_type_id);
-        }
-        let (filtered_source_ids, filtered_target_ids, filtered_rows) =
-            Self::get_filtered_sources_targets_rows(graph, min_degree, rows);
-        let mut filtered_node_map: FxHashMap<NodeId, Node> =
-            Self::init_nodes(&filtered_source_ids, &filtered_target_ids, &target_type_ids);
-        Self::populate_edges(&filtered_rows, &mut filtered_node_map)?;
-        Self::create_graph(filtered_node_map, filtered_source_ids, filtered_target_ids)
-    }
-    /// called by `prune`, finds source and target nodes to exclude, as well as edges to exclude
-    /// when rebuilding the graph from a filtered vector of `EdgeRows`.
-    fn get_filtered_sources_targets_rows(
-        mut graph: TGraph,
-        min_degree: usize,
-        rows: &[EdgeRow],
-    ) -> (Vec<NodeId>, Vec<NodeId>, Vec<EdgeRow>) {
-        let exclude_nodes: HashSet<NodeId> = Self::trim_edges(graph.get_mut_nodes(), &min_degree);
-        let filtered_source_ids: Vec<NodeId> = graph
-            .get_core_ids()
-            .iter()
-            .filter(|x| !exclude_nodes.contains(x))
-            .cloned()
-            .collect();
-        let filtered_target_ids: Vec<NodeId> = graph
-            .get_non_core_ids()
-            .unwrap()
-            .iter()
-            .filter(|x| !exclude_nodes.contains(x))
-            .cloned()
-            .collect();
-        let filtered_rows: Vec<EdgeRow> = rows
-            .iter()
-            .filter(|x| {
-                !(exclude_nodes.contains(&x.source_id) || (exclude_nodes.contains(&x.target_id)))
-            })
-            .cloned()
-            .collect();
-        // todo: make member of struct
-        (filtered_source_ids, filtered_target_ids, filtered_rows)
-    }
+    
 }

--- a/src/dachshund/graph_builder_base.rs
+++ b/src/dachshund/graph_builder_base.rs
@@ -11,6 +11,6 @@ where
     Self::GraphType: GraphBase,
 {
     type GraphType;
-
-    fn from_vector(&self, data: &Vec<(i64, i64)>) -> Self::GraphType;
+    type RowType;
+    fn from_vector(&self, data: &Vec<Self::RowType>) -> Self::GraphType;
 }

--- a/src/dachshund/graph_builder_base.rs
+++ b/src/dachshund/graph_builder_base.rs
@@ -4,7 +4,9 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+use crate::dachshund::error::CLQResult;
 use crate::dachshund::graph_base::GraphBase;
+
 pub trait GraphBuilderBase
 where
     Self: Sized,
@@ -12,5 +14,5 @@ where
 {
     type GraphType;
     type RowType;
-    fn from_vector(&self, data: &Vec<Self::RowType>) -> Self::GraphType;
+    fn from_vector(&self, data: &Vec<Self::RowType>) -> CLQResult<Self::GraphType>;
 }

--- a/src/dachshund/mod.rs
+++ b/src/dachshund/mod.rs
@@ -9,7 +9,6 @@ pub mod beam;
 pub mod candidate;
 pub mod error;
 pub mod graph_base;
-pub mod graph_builder;
 pub mod graph_builder_base;
 pub mod id_types;
 pub mod input;

--- a/src/dachshund/simple_directed_graph_builder.rs
+++ b/src/dachshund/simple_directed_graph_builder.rs
@@ -17,7 +17,9 @@ use std::collections::{BTreeMap, BTreeSet};
 pub struct SimpleDirectedGraphBuilder {}
 
 impl GraphBuilderBase for SimpleDirectedGraphBuilder {
+
     type GraphType = SimpleDirectedGraph;
+    type RowType = (i64, i64);
 
     // builds a graph from a vector of IDs. Repeated edges are ignored.
     fn from_vector(&self, data: &Vec<(i64, i64)>) -> SimpleDirectedGraph {

--- a/src/dachshund/simple_directed_graph_builder.rs
+++ b/src/dachshund/simple_directed_graph_builder.rs
@@ -7,6 +7,7 @@
 extern crate fxhash;
 extern crate nalgebra as na;
 
+use crate::dachshund::error::CLQResult;
 use crate::dachshund::graph_builder_base::GraphBuilderBase;
 use crate::dachshund::id_types::NodeId;
 use crate::dachshund::node::SimpleDirectedNode;
@@ -17,12 +18,12 @@ use std::collections::{BTreeMap, BTreeSet};
 pub struct SimpleDirectedGraphBuilder {}
 
 impl GraphBuilderBase for SimpleDirectedGraphBuilder {
-
     type GraphType = SimpleDirectedGraph;
     type RowType = (i64, i64);
 
     // builds a graph from a vector of IDs. Repeated edges are ignored.
-    fn from_vector(&self, data: &Vec<(i64, i64)>) -> SimpleDirectedGraph {
+    #[allow(clippy::ptr_arg)]
+    fn from_vector(&self, data: &Vec<(i64, i64)>) -> CLQResult<SimpleDirectedGraph> {
         let mut ids: BTreeMap<NodeId, (BTreeSet<NodeId>, BTreeSet<NodeId>)> = BTreeMap::new();
         for (id1, id2) in data {
             ids.entry(NodeId::from(*id1))
@@ -45,9 +46,9 @@ impl GraphBuilderBase for SimpleDirectedGraphBuilder {
                 },
             );
         }
-        SimpleDirectedGraph {
+        Ok(SimpleDirectedGraph {
             ids: nodes.keys().cloned().collect(),
             nodes: nodes,
-        }
+        })
     }
 }

--- a/src/dachshund/simple_transformer.rs
+++ b/src/dachshund/simple_transformer.rs
@@ -129,7 +129,7 @@ impl TransformerBase for SimpleTransformer {
     ) -> CLQResult<()> {
         let tuples: Vec<(i64, i64)> = self.batch.iter().map(|x| x.as_tuple()).collect();
         let builder = SimpleUndirectedGraphBuilder {};
-        let graph = builder.from_vector(&tuples);
+        let graph = builder.from_vector(&tuples)?;
         let stats = Self::compute_graph_stats_json(&graph);
         let original_id = self
             .line_processor
@@ -161,7 +161,7 @@ impl TransformerBase for SimpleParallelTransformer {
         let line_processor = self.line_processor.clone();
         self.pool.spawn(move || {
             let builder = SimpleUndirectedGraphBuilder {};
-            let graph = builder.from_vector(&tuples);
+            let graph = builder.from_vector(&tuples).unwrap();
             let stats = Self::compute_graph_stats_json(&graph);
             let original_id = line_processor.get_original_id(graph_id.value() as usize);
             let line: String = format!("{}\t{}", original_id, stats);

--- a/src/dachshund/simple_undirected_graph_builder.rs
+++ b/src/dachshund/simple_undirected_graph_builder.rs
@@ -16,7 +16,8 @@ use itertools::Itertools;
 use rand::prelude::*;
 pub struct SimpleUndirectedGraphBuilder {}
 
-pub trait TSimpleUndirectedGraphBuilder: GraphBuilderBase {
+pub trait TSimpleUndirectedGraphBuilder: GraphBuilderBase<RowType=(i64, i64)> {
+
     // Build a graph with n vertices with every possible edge.
     fn get_complete_graph(&self, n: u64) -> Self::GraphType {
         let mut v = Vec::new();
@@ -100,6 +101,7 @@ pub trait TSimpleUndirectedGraphBuilder: GraphBuilderBase {
 
 impl GraphBuilderBase for SimpleUndirectedGraphBuilder {
     type GraphType = SimpleUndirectedGraph;
+    type RowType = (i64, i64);
 
     // builds a graph from a vector of IDs. Repeated edges are ignored.
     // Edges only need to be provided once (this being an undirected graph)
@@ -126,6 +128,7 @@ impl SimpleUndirectedGraphBuilderWithCliques {
 impl TSimpleUndirectedGraphBuilder for SimpleUndirectedGraphBuilderWithCliques {}
 impl GraphBuilderBase for SimpleUndirectedGraphBuilderWithCliques {
     type GraphType = SimpleUndirectedGraph;
+    type RowType = (i64, i64);
 
     // builds a graph from a vector of IDs. Repeated edges are ignored.
     // Edges only need to be provided once (this being an undirected graph)

--- a/src/dachshund/simple_undirected_graph_builder.rs
+++ b/src/dachshund/simple_undirected_graph_builder.rs
@@ -4,6 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+use crate::dachshund::error::CLQResult;
 use crate::dachshund::graph_builder_base::GraphBuilderBase;
 use crate::dachshund::id_types::NodeId;
 use crate::dachshund::node::SimpleNode;
@@ -16,10 +17,9 @@ use itertools::Itertools;
 use rand::prelude::*;
 pub struct SimpleUndirectedGraphBuilder {}
 
-pub trait TSimpleUndirectedGraphBuilder: GraphBuilderBase<RowType=(i64, i64)> {
-
+pub trait TSimpleUndirectedGraphBuilder: GraphBuilderBase<RowType = (i64, i64)> {
     // Build a graph with n vertices with every possible edge.
-    fn get_complete_graph(&self, n: u64) -> Self::GraphType {
+    fn get_complete_graph(&self, n: u64) -> CLQResult<Self::GraphType> {
         let mut v = Vec::new();
         for i in 1..n {
             for j in i + 1..=n {
@@ -31,7 +31,7 @@ pub trait TSimpleUndirectedGraphBuilder: GraphBuilderBase<RowType=(i64, i64)> {
 
     // Build a graph with a sequence of n vertices with an edge between
     // each pair of successive vertices.
-    fn get_path_graph(&self, n: u64) -> Self::GraphType {
+    fn get_path_graph(&self, n: u64) -> CLQResult<Self::GraphType> {
         let mut v = Vec::new();
         for i in 0..n {
             v.push((i, (i + 1)));
@@ -43,7 +43,7 @@ pub trait TSimpleUndirectedGraphBuilder: GraphBuilderBase<RowType=(i64, i64)> {
     // Build a graph with a sequence of n vertices with an edge between
     // each pair of successive vertices, plus an edge between the first and
     // last vertices.
-    fn get_cycle_graph(&self, n: u64) -> Self::GraphType {
+    fn get_cycle_graph(&self, n: u64) -> CLQResult<Self::GraphType> {
         let mut v = Vec::new();
         for i in 0..n {
             v.push((i, (i + 1) % n));
@@ -57,7 +57,7 @@ pub trait TSimpleUndirectedGraphBuilder: GraphBuilderBase<RowType=(i64, i64)> {
     //  probability p.)
     // [TODO] Switch to the faster implementation using geometric distributions
     // for sparse graphs.
-    fn get_er_graph(&self, n: u64, p: f64) -> Self::GraphType {
+    fn get_er_graph(&self, n: u64, p: f64) -> CLQResult<Self::GraphType> {
         let mut v = Vec::new();
         let mut rng = rand::thread_rng();
 
@@ -105,13 +105,14 @@ impl GraphBuilderBase for SimpleUndirectedGraphBuilder {
 
     // builds a graph from a vector of IDs. Repeated edges are ignored.
     // Edges only need to be provided once (this being an undirected graph)
-    fn from_vector(&self, data: &Vec<(i64, i64)>) -> SimpleUndirectedGraph {
+    #[allow(clippy::ptr_arg)]
+    fn from_vector(&self, data: &Vec<(i64, i64)>) -> CLQResult<SimpleUndirectedGraph> {
         let ids = Self::get_node_ids(data);
         let nodes = Self::get_nodes(ids);
-        SimpleUndirectedGraph {
+        Ok(SimpleUndirectedGraph {
             ids: nodes.keys().cloned().collect(),
             nodes,
-        }
+        })
     }
 }
 impl TSimpleUndirectedGraphBuilder for SimpleUndirectedGraphBuilder {}
@@ -132,7 +133,8 @@ impl GraphBuilderBase for SimpleUndirectedGraphBuilderWithCliques {
 
     // builds a graph from a vector of IDs. Repeated edges are ignored.
     // Edges only need to be provided once (this being an undirected graph)
-    fn from_vector(&self, data: &Vec<(i64, i64)>) -> SimpleUndirectedGraph {
+    #[allow(clippy::ptr_arg)]
+    fn from_vector(&self, data: &Vec<(i64, i64)>) -> CLQResult<SimpleUndirectedGraph> {
         let ids = Self::get_node_ids(data);
         let mut nodes = Self::get_nodes(ids);
         for clique in &self.cliques {
@@ -145,9 +147,9 @@ impl GraphBuilderBase for SimpleUndirectedGraphBuilderWithCliques {
                 node.neighbors.insert(*id1);
             }
         }
-        SimpleUndirectedGraph {
+        Ok(SimpleUndirectedGraph {
             ids: nodes.keys().cloned().collect(),
             nodes,
-        }
+        })
     }
 }

--- a/src/dachshund/transformer.rs
+++ b/src/dachshund/transformer.rs
@@ -42,7 +42,6 @@ pub struct Transformer {
     clique_rows: Vec<CliqueRow>,
 }
 impl TransformerBase for Transformer {
-
     fn get_line_processor(&self) -> Arc<dyn LineProcessorBase> {
         self.line_processor.clone()
     }
@@ -241,10 +240,11 @@ impl Transformer {
         graph_id: GraphId,
         rows: &Vec<EdgeRow>,
     ) -> CLQResult<TypedGraph> {
-        TypedGraphBuilder{
+        TypedGraphBuilder {
             graph_id,
             min_degree: Some(self.search_problem.min_degree),
-        }.from_vector(rows)
+        }
+        .from_vector(rows)
     }
 
     /// Given a properly-built graph, runs the quasi-clique detection beam search on it.

--- a/src/dachshund/transformer.rs
+++ b/src/dachshund/transformer.rs
@@ -12,10 +12,9 @@ use clap::ArgMatches;
 use crate::dachshund::beam::{Beam, BeamSearchResult};
 use crate::dachshund::error::{CLQError, CLQResult};
 use crate::dachshund::graph_base::GraphBase;
-use crate::dachshund::graph_builder::GraphBuilder;
+use crate::dachshund::graph_builder_base::GraphBuilderBase;
 use crate::dachshund::id_types::{GraphId, NodeTypeId};
 use crate::dachshund::line_processor::LineProcessorBase;
-use crate::dachshund::node::Node;
 use crate::dachshund::non_core_type_ids::NonCoreTypeIds;
 use crate::dachshund::row::{CliqueRow, EdgeRow, Row};
 use crate::dachshund::search_problem::SearchProblem;
@@ -43,6 +42,7 @@ pub struct Transformer {
     clique_rows: Vec<CliqueRow>,
 }
 impl TransformerBase for Transformer {
+
     fn get_line_processor(&self) -> Arc<dyn LineProcessorBase> {
         self.line_processor.clone()
     }
@@ -65,9 +65,8 @@ impl TransformerBase for Transformer {
         graph_id: GraphId,
         output: &Sender<(Option<String>, bool)>,
     ) -> CLQResult<()> {
-        let graph: TypedGraph =
-            self.build_pruned_graph::<TypedGraphBuilder, TypedGraph>(graph_id, &self.edge_rows)?;
-        self.process_clique_rows::<TypedGraphBuilder, TypedGraph>(
+        let graph: TypedGraph = self.build_pruned_graph(graph_id, &self.edge_rows)?;
+        self.process_clique_rows(
             &graph,
             &self.clique_rows,
             graph_id,
@@ -237,26 +236,26 @@ impl Transformer {
     /// with other nodes in the graph. This is done via a greedy algorithm which removes
     /// low-degree nodes iteratively.
     #[allow(clippy::ptr_arg)]
-    pub fn build_pruned_graph<
-        TGraphBuilder: GraphBuilder<TGraph>,
-        TGraph: GraphBase<NodeType = Node>,
-    >(
+    pub fn build_pruned_graph(
         &self,
         graph_id: GraphId,
         rows: &Vec<EdgeRow>,
-    ) -> CLQResult<TGraph> {
-        TGraphBuilder::new(graph_id, rows, Some(self.search_problem.min_degree))
+    ) -> CLQResult<TypedGraph> {
+        TypedGraphBuilder{
+            graph_id,
+            min_degree: Some(self.search_problem.min_degree),
+        }.from_vector(rows)
     }
 
     /// Given a properly-built graph, runs the quasi-clique detection beam search on it.
-    pub fn process_graph<'a, TGraph: GraphBase<NodeType = Node>>(
+    pub fn process_graph<'a>(
         &'a self,
-        graph: &'a TGraph,
+        graph: &'a TypedGraph,
         clique_rows: &'a Vec<CliqueRow>,
         graph_id: GraphId,
         verbose: bool,
-    ) -> CLQResult<BeamSearchResult<'a, TGraph>> {
-        let mut beam: Beam<TGraph> = Beam::new(
+    ) -> CLQResult<BeamSearchResult<'a, TypedGraph>> {
+        let mut beam: Beam<TypedGraph> = Beam::new(
             graph,
             clique_rows,
             verbose,
@@ -269,18 +268,14 @@ impl Transformer {
     }
     /// Used to "seed" the beam search with an existing best (quasi-)clique (if any provided),
     /// and then run the search under the parameters specified in the constructor.
-    pub fn process_clique_rows<
-        'a,
-        TGraphBuilder: GraphBuilder<TGraph>,
-        TGraph: GraphBase<NodeType = Node>,
-    >(
+    pub fn process_clique_rows<'a>(
         &'a self,
-        graph: &'a TGraph,
+        graph: &'a TypedGraph,
         clique_rows: &'a Vec<CliqueRow>,
         graph_id: GraphId,
         verbose: bool,
         output: &Sender<(Option<String>, bool)>,
-    ) -> CLQResult<Option<BeamSearchResult<'a, TGraph>>> {
+    ) -> CLQResult<Option<BeamSearchResult<'a, TypedGraph>>> {
         if graph.get_core_ids().is_empty() || graph.get_non_core_ids().unwrap().is_empty() {
             // still have to send an acknowledgement to the output channel
             // that we have actually processed this graph, otherwise
@@ -289,7 +284,7 @@ impl Transformer {
             output.send((None, false)).unwrap();
             return Ok(None);
         }
-        let result: BeamSearchResult<TGraph> =
+        let result: BeamSearchResult<TypedGraph> =
             self.process_graph(graph, clique_rows, graph_id, verbose)?;
         // only print if this is a conforming clique
         if result.top_candidate.get_score()? > 0.0 {

--- a/src/dachshund/typed_graph_builder.rs
+++ b/src/dachshund/typed_graph_builder.rs
@@ -16,7 +16,7 @@ use fxhash::FxHashMap;
 
 pub struct TypedGraphBuilder {}
 impl GraphBuilder<TypedGraph> for TypedGraphBuilder {
-    fn _new(
+    fn create_graph(
         nodes: FxHashMap<NodeId, Node>,
         core_ids: Vec<NodeId>,
         non_core_ids: Vec<NodeId>,

--- a/src/dachshund/typed_graph_builder.rs
+++ b/src/dachshund/typed_graph_builder.rs
@@ -16,7 +16,6 @@ use fxhash::FxHashMap;
 
 pub struct TypedGraphBuilder {}
 impl GraphBuilder<TypedGraph> for TypedGraphBuilder {
-
     fn create_graph(
         nodes: FxHashMap<NodeId, Node>,
         core_ids: Vec<NodeId>,

--- a/src/dachshund/typed_graph_builder.rs
+++ b/src/dachshund/typed_graph_builder.rs
@@ -9,7 +9,7 @@ extern crate fxhash;
 use crate::dachshund::error::{CLQError, CLQResult};
 use crate::dachshund::graph_base::GraphBase;
 use crate::dachshund::graph_builder_base::GraphBuilderBase;
-use crate::dachshund::id_types::{GraphId, NodeTypeId, NodeId};
+use crate::dachshund::id_types::{GraphId, NodeId, NodeTypeId};
 use crate::dachshund::node::{Node, NodeBase, NodeEdge};
 use crate::dachshund::row::EdgeRow;
 use crate::dachshund::typed_graph::TypedGraph;
@@ -21,7 +21,6 @@ pub struct TypedGraphBuilder {
     pub graph_id: GraphId,
 }
 impl GraphBuilderBase for TypedGraphBuilder {
-
     type GraphType = TypedGraph;
     type RowType = EdgeRow;
 
@@ -65,7 +64,7 @@ impl TypedGraphBuilder {
             non_core_ids,
         })
     }
-    
+
     /// given a set of initialized Nodes, populates the respective neighbors fields
     /// appropriately.
     fn populate_edges(rows: &[EdgeRow], node_map: &mut FxHashMap<NodeId, Node>) -> CLQResult<()> {
@@ -148,11 +147,13 @@ impl TypedGraphBuilder {
         node_map
     }
 
-
     /// Trims edges greedily, until all edges in the graph have degree at least min_degree.
     /// Note that this function does not delete any nodes -- just finds nodes to delete. It is
     /// called by `prune`, which actually does the deletion.
-    pub fn trim_edges(node_map: &mut FxHashMap<NodeId, Node>, min_degree: &usize) -> HashSet<NodeId> {
+    pub fn trim_edges(
+        node_map: &mut FxHashMap<NodeId, Node>,
+        min_degree: &usize,
+    ) -> HashSet<NodeId> {
         let mut degree_map: HashMap<NodeId, usize> = HashMap::new();
         for (node_id, node) in node_map.iter() {
             let node_degree: usize = node.degree();
@@ -181,12 +182,16 @@ impl TypedGraphBuilder {
         }
         nodes_to_delete
     }
-    
+
     /// Takes an already-built graph and the edge rows used to create it, returning a
     /// new graph, where all nodes are assured to have degree at least min_degree.
     /// The provision of a <Self as GraphBuilderBase>::GraphType is necessary, since the notion of "degree" does
     /// not make sense outside of a graph.
-    pub fn prune(graph: <Self as GraphBuilderBase>::GraphType, rows: &[EdgeRow], min_degree: usize) -> CLQResult<<Self as GraphBuilderBase>::GraphType> {
+    pub fn prune(
+        graph: <Self as GraphBuilderBase>::GraphType,
+        rows: &[EdgeRow],
+        min_degree: usize,
+    ) -> CLQResult<<Self as GraphBuilderBase>::GraphType> {
         let mut target_type_ids: HashMap<NodeId, NodeTypeId> = HashMap::new();
         for r in rows.iter() {
             target_type_ids.insert(r.target_id, r.target_type_id);

--- a/src/dachshund/typed_graph_builder.rs
+++ b/src/dachshund/typed_graph_builder.rs
@@ -7,15 +7,53 @@
 extern crate fxhash;
 
 use crate::dachshund::error::{CLQError, CLQResult};
-use crate::dachshund::graph_builder::GraphBuilder;
-use crate::dachshund::id_types::NodeId;
-use crate::dachshund::node::{Node, NodeEdge};
+use crate::dachshund::graph_base::GraphBase;
+use crate::dachshund::graph_builder_base::GraphBuilderBase;
+use crate::dachshund::id_types::{GraphId, NodeTypeId, NodeId};
+use crate::dachshund::node::{Node, NodeBase, NodeEdge};
 use crate::dachshund::row::EdgeRow;
 use crate::dachshund::typed_graph::TypedGraph;
 use fxhash::FxHashMap;
+use std::collections::{HashMap, HashSet};
 
-pub struct TypedGraphBuilder {}
-impl GraphBuilder<TypedGraph> for TypedGraphBuilder {
+pub struct TypedGraphBuilder {
+    pub min_degree: Option<usize>,
+    pub graph_id: GraphId,
+}
+impl GraphBuilderBase for TypedGraphBuilder {
+
+    type GraphType = TypedGraph;
+    type RowType = EdgeRow;
+
+    fn from_vector(&self, rows: &Vec<EdgeRow>) -> CLQResult<TypedGraph> {
+        let mut source_ids: HashSet<NodeId> = HashSet::new();
+        let mut target_ids: HashSet<NodeId> = HashSet::new();
+        let mut target_type_ids: HashMap<NodeId, NodeTypeId> = HashMap::new();
+        for r in rows.iter() {
+            assert!(self.graph_id == r.graph_id);
+            source_ids.insert(r.source_id);
+            target_ids.insert(r.target_id);
+            target_type_ids.insert(r.target_id, r.target_type_id);
+        }
+
+        // warrant a canonical order on the id vectors
+        let mut source_ids_vec: Vec<NodeId> = source_ids.into_iter().collect();
+        source_ids_vec.sort();
+        let mut target_ids_vec: Vec<NodeId> = target_ids.into_iter().collect();
+        target_ids_vec.sort();
+
+        let mut node_map: FxHashMap<NodeId, Node> =
+            Self::init_nodes(&source_ids_vec, &target_ids_vec, &target_type_ids);
+        Self::populate_edges(rows, &mut node_map)?;
+        let mut graph = Self::create_graph(node_map, source_ids_vec, target_ids_vec)?;
+        if let Some(min_degree) = self.min_degree {
+            graph = Self::prune(graph, rows, min_degree)?;
+        }
+        Ok(graph)
+    }
+}
+
+impl TypedGraphBuilder {
     fn create_graph(
         nodes: FxHashMap<NodeId, Node>,
         core_ids: Vec<NodeId>,
@@ -78,5 +116,117 @@ impl GraphBuilder<TypedGraph> for TypedGraphBuilder {
             }
         }
         Ok(())
+    }
+
+    // initializes nodes in the graph with empty neighbors fields.
+    fn init_nodes(
+        core_ids: &[NodeId],
+        non_core_ids: &[NodeId],
+        non_core_type_ids: &HashMap<NodeId, NodeTypeId>,
+    ) -> FxHashMap<NodeId, Node> {
+        let mut node_map: FxHashMap<NodeId, Node> = FxHashMap::default();
+        for &id in core_ids {
+            let node = Node::new(
+                id,             // node_id,
+                true,           // is_core,
+                None,           // non_core_type,
+                Vec::new(),     // edges,
+                HashMap::new(), //neighbors
+            );
+            node_map.insert(id, node);
+        }
+        for &id in non_core_ids {
+            let node = Node::new(
+                id,                           // node_id,
+                false,                        // is_core,
+                Some(non_core_type_ids[&id]), // non_core_type,
+                Vec::new(),                   // edges,
+                HashMap::new(),               // neighbors
+            );
+            node_map.insert(id, node);
+        }
+        node_map
+    }
+
+
+    /// Trims edges greedily, until all edges in the graph have degree at least min_degree.
+    /// Note that this function does not delete any nodes -- just finds nodes to delete. It is
+    /// called by `prune`, which actually does the deletion.
+    pub fn trim_edges(node_map: &mut FxHashMap<NodeId, Node>, min_degree: &usize) -> HashSet<NodeId> {
+        let mut degree_map: HashMap<NodeId, usize> = HashMap::new();
+        for (node_id, node) in node_map.iter() {
+            let node_degree: usize = node.degree();
+            degree_map.insert(*node_id, node_degree);
+        }
+        let mut nodes_to_delete: HashSet<NodeId> = HashSet::new();
+        loop {
+            let mut nodes_to_update: HashSet<NodeId> = HashSet::new();
+            for (node_id, node_degree) in degree_map.iter() {
+                if node_degree < min_degree && !nodes_to_delete.contains(node_id) {
+                    nodes_to_update.insert(*node_id);
+                    nodes_to_delete.insert(*node_id);
+                }
+            }
+            if nodes_to_update.is_empty() {
+                break;
+            }
+            for node_id in nodes_to_update.iter() {
+                let node: &Node = &node_map[node_id];
+                for n in node.edges.iter() {
+                    let neighbor_node_id: NodeId = n.target_id;
+                    let current_degree: usize = degree_map[&neighbor_node_id];
+                    degree_map.insert(neighbor_node_id, current_degree - 1);
+                }
+            }
+        }
+        nodes_to_delete
+    }
+    
+    /// Takes an already-built graph and the edge rows used to create it, returning a
+    /// new graph, where all nodes are assured to have degree at least min_degree.
+    /// The provision of a <Self as GraphBuilderBase>::GraphType is necessary, since the notion of "degree" does
+    /// not make sense outside of a graph.
+    pub fn prune(graph: <Self as GraphBuilderBase>::GraphType, rows: &[EdgeRow], min_degree: usize) -> CLQResult<<Self as GraphBuilderBase>::GraphType> {
+        let mut target_type_ids: HashMap<NodeId, NodeTypeId> = HashMap::new();
+        for r in rows.iter() {
+            target_type_ids.insert(r.target_id, r.target_type_id);
+        }
+        let (filtered_source_ids, filtered_target_ids, filtered_rows) =
+            Self::get_filtered_sources_targets_rows(graph, min_degree, rows);
+        let mut filtered_node_map: FxHashMap<NodeId, Node> =
+            Self::init_nodes(&filtered_source_ids, &filtered_target_ids, &target_type_ids);
+        Self::populate_edges(&filtered_rows, &mut filtered_node_map)?;
+        Self::create_graph(filtered_node_map, filtered_source_ids, filtered_target_ids)
+    }
+    /// called by `prune`, finds source and target nodes to exclude, as well as edges to exclude
+    /// when rebuilding the graph from a filtered vector of `EdgeRows`.
+    fn get_filtered_sources_targets_rows(
+        mut graph: <Self as GraphBuilderBase>::GraphType,
+        min_degree: usize,
+        rows: &[EdgeRow],
+    ) -> (Vec<NodeId>, Vec<NodeId>, Vec<EdgeRow>) {
+        let exclude_nodes: HashSet<NodeId> = Self::trim_edges(graph.get_mut_nodes(), &min_degree);
+        let filtered_source_ids: Vec<NodeId> = graph
+            .get_core_ids()
+            .iter()
+            .filter(|x| !exclude_nodes.contains(x))
+            .cloned()
+            .collect();
+        let filtered_target_ids: Vec<NodeId> = graph
+            .get_non_core_ids()
+            .unwrap()
+            .iter()
+            .filter(|x| !exclude_nodes.contains(x))
+            .cloned()
+            .collect();
+        let filtered_rows: Vec<EdgeRow> = rows
+            .iter()
+            .filter(|x| {
+                !(exclude_nodes.contains(&x.source_id) || (exclude_nodes.contains(&x.target_id)))
+            })
+            .cloned()
+            .collect();
+        // todo: make member of struct
+        (filtered_source_ids, filtered_target_ids, filtered_rows)
     }
 }

--- a/src/dachshund/typed_graph_builder.rs
+++ b/src/dachshund/typed_graph_builder.rs
@@ -6,10 +6,11 @@
  */
 extern crate fxhash;
 
-use crate::dachshund::error::CLQResult;
+use crate::dachshund::error::{CLQError, CLQResult};
 use crate::dachshund::graph_builder::GraphBuilder;
 use crate::dachshund::id_types::NodeId;
-use crate::dachshund::node::Node;
+use crate::dachshund::node::{Node, NodeEdge};
+use crate::dachshund::row::EdgeRow;
 use crate::dachshund::typed_graph::TypedGraph;
 use fxhash::FxHashMap;
 
@@ -25,5 +26,57 @@ impl GraphBuilder<TypedGraph> for TypedGraphBuilder {
             core_ids,
             non_core_ids,
         })
+    }
+    
+    /// given a set of initialized Nodes, populates the respective neighbors fields
+    /// appropriately.
+    fn populate_edges(rows: &[EdgeRow], node_map: &mut FxHashMap<NodeId, Node>) -> CLQResult<()> {
+        for r in rows.iter() {
+            assert!(node_map.contains_key(&r.source_id));
+            assert!(node_map.contains_key(&r.target_id));
+
+            let source_node = node_map
+                .get_mut(&r.source_id)
+                .ok_or_else(CLQError::err_none)?;
+
+            source_node
+                .neighbors
+                .entry(r.target_id)
+                .or_insert_with(Vec::new);
+            source_node
+                .neighbors
+                .get_mut(&r.target_id)
+                .unwrap()
+                .push(NodeEdge::new(r.edge_type_id, r.target_id));
+
+            // probably unnecessary.
+            node_map
+                .get_mut(&r.source_id)
+                .ok_or_else(CLQError::err_none)?
+                .edges
+                .push(NodeEdge::new(r.edge_type_id, r.target_id));
+
+            // edges with the same source and target type should not be repeated
+            if r.source_type_id != r.target_type_id {
+                let target_node = node_map
+                    .get_mut(&r.target_id)
+                    .ok_or_else(CLQError::err_none)?;
+
+                target_node
+                    .neighbors
+                    .entry(r.source_id)
+                    .or_insert_with(Vec::new);
+                target_node
+                    .neighbors
+                    .get_mut(&r.source_id)
+                    .unwrap()
+                    .push(NodeEdge::new(r.edge_type_id, r.source_id));
+
+                target_node
+                    .edges
+                    .push(NodeEdge::new(r.edge_type_id, r.source_id));
+            }
+        }
+        Ok(())
     }
 }

--- a/src/dachshund/typed_graph_builder.rs
+++ b/src/dachshund/typed_graph_builder.rs
@@ -16,6 +16,7 @@ use fxhash::FxHashMap;
 
 pub struct TypedGraphBuilder {}
 impl GraphBuilder<TypedGraph> for TypedGraphBuilder {
+
     fn create_graph(
         nodes: FxHashMap<NodeId, Node>,
         core_ids: Vec<NodeId>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,6 @@ pub use dachshund::algorithms::transitivity::Transitivity;
 pub use dachshund::beam::Beam;
 pub use dachshund::candidate::Candidate;
 pub use dachshund::graph_base::GraphBase;
-pub use dachshund::graph_builder::GraphBuilder;
 pub use dachshund::graph_builder_base::GraphBuilderBase;
 pub use dachshund::id_types::{EdgeTypeId, GraphId, NodeId, NodeTypeId};
 pub use dachshund::input::Input;

--- a/tests/beam.rs
+++ b/tests/beam.rs
@@ -50,8 +50,7 @@ fn test_init_beam_with_clique_rows() -> CLQResult<()> {
         CliqueRow::new(graph_id, 3, Some(article_type)),
         CliqueRow::new(graph_id, 4, Some(article_type)),
     ];
-    let graph: TypedGraph =
-        transformer.build_pruned_graph(graph_id, &rows)?;
+    let graph: TypedGraph = transformer.build_pruned_graph(graph_id, &rows)?;
     let test_node_id: NodeId = NodeId::from(3 as i64);
     graph.nodes[&test_node_id]
         .non_core_type
@@ -99,8 +98,7 @@ fn test_init_beam_with_partially_overlapping_clique_rows() -> CLQResult<()> {
         CliqueRow::new(graph_id, 4, Some(article_type)),
         CliqueRow::new(graph_id, 7, Some(article_type)),
     ];
-    let graph: TypedGraph =
-        transformer.build_pruned_graph(graph_id, &rows)?;
+    let graph: TypedGraph = transformer.build_pruned_graph(graph_id, &rows)?;
     let beam: Beam<TypedGraph> = Beam::new(
         &graph,
         &clique_rows,

--- a/tests/beam.rs
+++ b/tests/beam.rs
@@ -23,7 +23,6 @@ use lib_dachshund::dachshund::test_utils::{
 use lib_dachshund::dachshund::transformer::Transformer;
 use lib_dachshund::dachshund::transformer_base::TransformerBase;
 use lib_dachshund::dachshund::typed_graph::TypedGraph;
-use lib_dachshund::dachshund::typed_graph_builder::TypedGraphBuilder;
 
 #[cfg(test)]
 #[test]
@@ -52,7 +51,7 @@ fn test_init_beam_with_clique_rows() -> CLQResult<()> {
         CliqueRow::new(graph_id, 4, Some(article_type)),
     ];
     let graph: TypedGraph =
-        transformer.build_pruned_graph::<TypedGraphBuilder, TypedGraph>(graph_id, &rows)?;
+        transformer.build_pruned_graph(graph_id, &rows)?;
     let test_node_id: NodeId = NodeId::from(3 as i64);
     graph.nodes[&test_node_id]
         .non_core_type
@@ -101,7 +100,7 @@ fn test_init_beam_with_partially_overlapping_clique_rows() -> CLQResult<()> {
         CliqueRow::new(graph_id, 7, Some(article_type)),
     ];
     let graph: TypedGraph =
-        transformer.build_pruned_graph::<TypedGraphBuilder, TypedGraph>(graph_id, &rows)?;
+        transformer.build_pruned_graph(graph_id, &rows)?;
     let beam: Beam<TypedGraph> = Beam::new(
         &graph,
         &clique_rows,

--- a/tests/candidate.rs
+++ b/tests/candidate.rs
@@ -57,8 +57,7 @@ fn test_rebuild_candidate() -> CLQResult<()> {
 
     let transformer: Transformer = gen_test_transformer(typespec, "author".to_string())?;
     let rows: Vec<EdgeRow> = process_raw_vector(&transformer, raw)?;
-    let graph: TypedGraph =
-        transformer.build_pruned_graph(graph_id, &rows)?;
+    let graph: TypedGraph = transformer.build_pruned_graph(graph_id, &rows)?;
     assert_eq!(graph.core_ids.len(), 1);
     let core_node_id: NodeId = *graph.core_ids.first().unwrap();
     assert_eq!(graph.non_core_ids.len(), 1);
@@ -109,9 +108,7 @@ fn build_sample_graph() -> (TypedGraph, Transformer) {
     let transformer: Transformer = gen_test_transformer(typespec, "author".to_string()).unwrap();
     let rows: Vec<EdgeRow> = process_raw_vector(&transformer, raw).unwrap();
     (
-        transformer
-            .build_pruned_graph(graph_id, &rows)
-            .unwrap(),
+        transformer.build_pruned_graph(graph_id, &rows).unwrap(),
         transformer,
     )
 }

--- a/tests/candidate.rs
+++ b/tests/candidate.rs
@@ -18,7 +18,6 @@ use lib_dachshund::dachshund::scorer::Scorer;
 use lib_dachshund::dachshund::test_utils::{gen_test_transformer, process_raw_vector};
 use lib_dachshund::dachshund::transformer::Transformer;
 use lib_dachshund::dachshund::typed_graph::TypedGraph;
-use lib_dachshund::dachshund::typed_graph_builder::TypedGraphBuilder;
 
 extern crate fxhash;
 use fxhash::FxHashMap;
@@ -59,7 +58,7 @@ fn test_rebuild_candidate() -> CLQResult<()> {
     let transformer: Transformer = gen_test_transformer(typespec, "author".to_string())?;
     let rows: Vec<EdgeRow> = process_raw_vector(&transformer, raw)?;
     let graph: TypedGraph =
-        transformer.build_pruned_graph::<TypedGraphBuilder, TypedGraph>(graph_id, &rows)?;
+        transformer.build_pruned_graph(graph_id, &rows)?;
     assert_eq!(graph.core_ids.len(), 1);
     let core_node_id: NodeId = *graph.core_ids.first().unwrap();
     assert_eq!(graph.non_core_ids.len(), 1);
@@ -111,7 +110,7 @@ fn build_sample_graph() -> (TypedGraph, Transformer) {
     let rows: Vec<EdgeRow> = process_raw_vector(&transformer, raw).unwrap();
     (
         transformer
-            .build_pruned_graph::<TypedGraphBuilder, TypedGraph>(graph_id, &rows)
+            .build_pruned_graph(graph_id, &rows)
             .unwrap(),
         transformer,
     )

--- a/tests/cnm.rs
+++ b/tests/cnm.rs
@@ -6,11 +6,12 @@
  */
 extern crate lib_dachshund;
 use lib_dachshund::dachshund::algorithms::cnm_communities::CNMCommunities;
+use lib_dachshund::dachshund::error::{CLQError, CLQResult};
 use lib_dachshund::dachshund::graph_builder_base::GraphBuilderBase;
 use lib_dachshund::dachshund::simple_undirected_graph::SimpleUndirectedGraph;
 use lib_dachshund::dachshund::simple_undirected_graph_builder::SimpleUndirectedGraphBuilder;
 
-fn get_graph(idx: usize) -> Result<SimpleUndirectedGraph, String> {
+fn get_graph(idx: usize) -> CLQResult<SimpleUndirectedGraph> {
     let v = match idx {
         0 => vec![(0, 1), (1, 2), (2, 0)],
         1 => vec![(0, 1), (1, 2), (2, 0), (3, 4), (4, 5), (5, 3)],
@@ -25,10 +26,10 @@ fn get_graph(idx: usize) -> Result<SimpleUndirectedGraph, String> {
             (4, 5),
             (1, 6),
         ],
-        _ => return Err("Invalid index".to_string()),
+        _ => return Err(CLQError::Generic("Invalid index".to_string())),
     };
-    Ok(SimpleUndirectedGraphBuilder {}
-        .from_vector(&v.into_iter().map(|(x, y)| (x as i64, y as i64)).collect()))
+    SimpleUndirectedGraphBuilder {}
+        .from_vector(&v.into_iter().map(|(x, y)| (x as i64, y as i64)).collect())
 }
 fn get_expected_modularity_changes(idx: usize) -> Result<Vec<f64>, String> {
     match idx {
@@ -39,8 +40,8 @@ fn get_expected_modularity_changes(idx: usize) -> Result<Vec<f64>, String> {
 
 #[cfg(test)]
 #[test]
-fn test_triad_cnm_iter() {
-    let g = get_graph(0).unwrap();
+fn test_triad_cnm_iter() -> CLQResult<()> {
+    let g = get_graph(0)?;
     let x = g.init_cnm_communities();
     assert_eq!(x.communities.len(), 3);
     assert_eq!(x.degree_map.len(), 3);
@@ -83,11 +84,12 @@ fn test_triad_cnm_iter() {
     assert_eq!(x.num_edges, 3);
 
     assert_eq!(x.degree_map[&2], 6);
+    Ok(())
 }
 
 #[test]
-fn test_triad_cnm_whole() {
-    let g = get_graph(0).unwrap();
+fn test_triad_cnm_whole() -> CLQResult<()> {
+    let g = get_graph(0)?;
     let (communities, _) = g.get_cnm_communities();
     assert_eq!(communities.len(), 1);
     assert_eq!(
@@ -97,11 +99,12 @@ fn test_triad_cnm_whole() {
             .collect::<Vec<usize>>()[0],
         3
     );
+    Ok(())
 }
 
 #[test]
-fn test_two_triads_cnm() {
-    let g = get_graph(1).unwrap();
+fn test_two_triads_cnm() -> CLQResult<()> {
+    let g = get_graph(1)?;
     let (communities, _) = g.get_cnm_communities();
     assert_eq!(communities.len(), 2);
     assert_eq!(
@@ -114,11 +117,12 @@ fn test_two_triads_cnm() {
     for k in communities.keys() {
         println!("Key: {}", k);
     }
+    Ok(())
 }
 
 #[test]
-fn test_tendril_cnm() {
-    let g = get_graph(2).unwrap();
+fn test_tendril_cnm() -> CLQResult<()> {
+    let g = get_graph(2)?;
     let x = g.init_cnm_communities();
     assert_eq!(x.communities.len(), 4);
     assert_eq!(x.degree_map.len(), 4);
@@ -129,14 +133,16 @@ fn test_tendril_cnm() {
 
     let (delta_ij, _i, _j) = x.maxh.peek().unwrap().tuple();
     assert_eq!(delta_ij, 2.0 / 8.0 - 2.0 * (1.0 * 3.0) / 64.0);
+    Ok(())
 }
 
 #[test]
-fn test_modularity_changes() {
-    let g = get_graph(3).unwrap();
+fn test_modularity_changes() -> CLQResult<()> {
+    let g = get_graph(3)?;
     let (_, modularity_changes) = g.get_cnm_communities();
     let expected = get_expected_modularity_changes(3).unwrap();
     for i in 0..expected.len() {
         assert_eq!(modularity_changes[i], expected[i]);
     }
+    Ok(())
 }

--- a/tests/karate_club.rs
+++ b/tests/karate_club.rs
@@ -25,6 +25,7 @@ use lib_dachshund::dachshund::algorithms::eigenvector_centrality::EigenvectorCen
 use lib_dachshund::dachshund::algorithms::laplacian::Laplacian;
 use lib_dachshund::dachshund::algorithms::shortest_paths::ShortestPaths;
 use lib_dachshund::dachshund::algorithms::transitivity::Transitivity;
+use lib_dachshund::dachshund::error::CLQResult;
 use lib_dachshund::dachshund::graph_base::GraphBase;
 use lib_dachshund::dachshund::graph_builder_base::GraphBuilderBase;
 use lib_dachshund::dachshund::id_types::NodeId;
@@ -120,8 +121,11 @@ fn get_karate_club_edges() -> Vec<(usize, usize)> {
         (33, 34),
     ]
 }
-fn _get_karate_club_graph_with_one_extra_edge<T, R>(builder: T) -> R
-where R: GraphBase, T: GraphBuilderBase<GraphType = R, RowType = (i64, i64)> {
+fn _get_karate_club_graph_with_one_extra_edge<T, R>(builder: T) -> CLQResult<R>
+where
+    R: GraphBase,
+    T: GraphBuilderBase<GraphType = R, RowType = (i64, i64)>,
+{
     let mut rows = get_karate_club_edges();
     rows.push((35, 36));
     builder.from_vector(
@@ -131,11 +135,11 @@ where R: GraphBase, T: GraphBuilderBase<GraphType = R, RowType = (i64, i64)> {
             .collect(),
     )
 }
-fn get_karate_club_graph_with_one_extra_edge() -> SimpleUndirectedGraph {
+fn get_karate_club_graph_with_one_extra_edge() -> CLQResult<SimpleUndirectedGraph> {
     let builder = SimpleUndirectedGraphBuilder {};
     _get_karate_club_graph_with_one_extra_edge::<SimpleUndirectedGraphBuilder, _>(builder)
 }
-fn get_directed_karate_club_graph_with_one_extra_edge() -> SimpleDirectedGraph {
+fn get_directed_karate_club_graph_with_one_extra_edge() -> CLQResult<SimpleDirectedGraph> {
     let builder = SimpleDirectedGraphBuilder {};
     _get_karate_club_graph_with_one_extra_edge::<SimpleDirectedGraphBuilder, _>(builder)
 }
@@ -148,8 +152,11 @@ fn get_two_karate_clubs_edges() -> Vec<(usize, usize)> {
     rows
 }
 
-fn _get_two_karate_clubs<T, R>(builder: T) -> R
-where R: GraphBase, T: GraphBuilderBase<GraphType = R, RowType = (i64, i64)> {
+fn _get_two_karate_clubs<T, R>(builder: T) -> CLQResult<R>
+where
+    R: GraphBase,
+    T: GraphBuilderBase<GraphType = R, RowType = (i64, i64)>,
+{
     let rows = get_two_karate_clubs_edges();
     builder.from_vector(
         &rows
@@ -158,11 +165,11 @@ where R: GraphBase, T: GraphBuilderBase<GraphType = R, RowType = (i64, i64)> {
             .collect(),
     )
 }
-fn get_two_karate_clubs() -> SimpleUndirectedGraph {
+fn get_two_karate_clubs() -> CLQResult<SimpleUndirectedGraph> {
     let builder = SimpleUndirectedGraphBuilder {};
     _get_two_karate_clubs::<SimpleUndirectedGraphBuilder, _>(builder)
 }
-fn get_directed_karate_club_graph_both_ways() -> SimpleDirectedGraph {
+fn get_directed_karate_club_graph_both_ways() -> CLQResult<SimpleDirectedGraph> {
     let rows = get_karate_club_edges();
     let builder = SimpleDirectedGraphBuilder {};
     let graph = builder.from_vector(
@@ -172,13 +179,15 @@ fn get_directed_karate_club_graph_both_ways() -> SimpleDirectedGraph {
             .map(|(x, y)| (x as i64, y as i64))
             .chain(rows.iter().cloned().map(|(x, y)| (y as i64, x as i64)))
             .collect(),
-    );
+    )?;
     for node in graph.get_nodes_iter() {
         assert_eq!(node.get_in_degree(), node.get_out_degree());
     }
-    graph
+    Ok(graph)
 }
-fn get_directed_karate_club_graph_with_core(core: HashSet<usize>) -> SimpleDirectedGraph {
+fn get_directed_karate_club_graph_with_core(
+    core: HashSet<usize>,
+) -> CLQResult<SimpleDirectedGraph> {
     let rows = get_karate_club_edges();
     let builder = SimpleDirectedGraphBuilder {};
     let graph = builder.from_vector(
@@ -197,8 +206,11 @@ fn get_directed_karate_club_graph_with_core(core: HashSet<usize>) -> SimpleDirec
     graph
 }
 
-fn _get_two_karate_clubs_with_bridge<T, R>(builder: T) -> R
-where R: GraphBase, T: GraphBuilderBase<GraphType = R, RowType = (i64, i64)> {
+fn _get_two_karate_clubs_with_bridge<T, R>(builder: T) -> CLQResult<R>
+where
+    R: GraphBase,
+    T: GraphBuilderBase<GraphType = R, RowType = (i64, i64)>,
+{
     let mut rows = get_two_karate_clubs_edges();
     rows.push((34, 35));
     builder.from_vector(
@@ -208,13 +220,16 @@ where R: GraphBase, T: GraphBuilderBase<GraphType = R, RowType = (i64, i64)> {
             .collect(),
     )
 }
-fn get_two_karate_clubs_with_bridge() -> SimpleUndirectedGraph {
+fn get_two_karate_clubs_with_bridge() -> CLQResult<SimpleUndirectedGraph> {
     let builder = SimpleUndirectedGraphBuilder {};
     _get_two_karate_clubs_with_bridge::<SimpleUndirectedGraphBuilder, _>(builder)
 }
 
-fn _get_karate_club_graph<T, R>(builder: T) -> R
-where R: GraphBase, T: GraphBuilderBase<GraphType = R, RowType = (i64, i64)> {
+fn _get_karate_club_graph<T, R>(builder: T) -> CLQResult<R>
+where
+    R: GraphBase,
+    T: GraphBuilderBase<GraphType = R, RowType = (i64, i64)>,
+{
     let rows = get_karate_club_edges();
     builder.from_vector(
         &rows
@@ -223,23 +238,25 @@ where R: GraphBase, T: GraphBuilderBase<GraphType = R, RowType = (i64, i64)> {
             .collect(),
     )
 }
-fn get_karate_club_graph() -> SimpleUndirectedGraph {
+fn get_karate_club_graph() -> CLQResult<SimpleUndirectedGraph> {
     let builder = SimpleUndirectedGraphBuilder {};
     _get_karate_club_graph::<SimpleUndirectedGraphBuilder, _>(builder)
 }
-fn get_directed_karate_club_graph() -> SimpleDirectedGraph {
+fn get_directed_karate_club_graph() -> CLQResult<SimpleDirectedGraph> {
     let builder = SimpleDirectedGraphBuilder {};
     _get_karate_club_graph::<SimpleDirectedGraphBuilder, _>(builder)
 }
-fn get_karate_club_graph_with_cliques(cliques: Vec<BTreeSet<NodeId>>) -> SimpleUndirectedGraph {
+fn get_karate_club_graph_with_cliques(
+    cliques: Vec<BTreeSet<NodeId>>,
+) -> CLQResult<SimpleUndirectedGraph> {
     let builder = SimpleUndirectedGraphBuilderWithCliques::new(cliques);
     _get_karate_club_graph::<SimpleUndirectedGraphBuilderWithCliques, _>(builder)
 }
 
 #[cfg(test)]
 #[test]
-fn test_karate_club() {
-    let graph = get_karate_club_graph();
+fn test_karate_club() -> CLQResult<()> {
+    let graph = get_karate_club_graph()?;
     assert_eq!(graph.nodes.len(), 34);
     assert_eq!(graph.count_edges(), 78);
     assert_eq!(graph.get_node_degree(NodeId::from(1 as i64)), 16);
@@ -277,11 +294,12 @@ fn test_karate_club() {
             .unwrap(),
         0.0
     );
+    Ok(())
 }
 
 #[test]
-fn test_shortest_paths() {
-    let graph = get_karate_club_graph();
+fn test_shortest_paths() -> CLQResult<()> {
+    let graph = get_karate_club_graph()?;
     let source = NodeId::from(1 as i64);
     let (dist, parents) = graph.get_shortest_paths(source, &None);
     assert_eq!(dist[&NodeId::from(1 as i64)], Some(0));
@@ -326,32 +344,35 @@ fn test_shortest_paths() {
     assert!(unrolled_paths.contains("1-3-33-16"));
     assert!(unrolled_paths.contains("1-9-33-16"));
     assert!(unrolled_paths.contains("1-32-33-16"));
+    Ok(())
 }
 
 #[bench]
-fn bench_shortest_paths(b: &mut Bencher) {
+fn bench_shortest_paths(b: &mut Bencher) -> CLQResult<()> {
     b.iter(|| {
-        let graph = get_karate_club_graph();
+        let graph = get_karate_club_graph().unwrap();
         let source = NodeId::from(1 as i64);
         let (_dist, _parents) = graph.get_shortest_paths(source, &None);
     });
+    Ok(())
 }
 
 #[bench]
-fn bench_shortest_paths_bfs(b: &mut Bencher) {
+fn bench_shortest_paths_bfs(b: &mut Bencher) -> CLQResult<()> {
     b.iter(|| {
-        let graph = get_karate_club_graph();
+        let graph = get_karate_club_graph().unwrap();
         let source = NodeId::from(1 as i64);
         let (_ordered_students, _dist, _preds) = graph.get_shortest_paths_bfs(source);
     });
+    Ok(())
 }
 
 #[test]
-fn test_connectivity() {
-    let graph = get_karate_club_graph();
+fn test_connectivity() -> CLQResult<()> {
+    let graph = get_karate_club_graph()?;
     assert!(graph.get_is_connected().unwrap());
-    let graph_unconnected = get_karate_club_graph_with_one_extra_edge();
-    assert!(!graph_unconnected.get_is_connected().unwrap());
+    let graph_unconnected = get_karate_club_graph_with_one_extra_edge()?;
+    assert!(!graph_unconnected.get_is_connected()?);
     let graph_empty = SimpleUndirectedGraph::create_empty();
     assert!(graph_empty.get_is_connected().is_err(), "Graph is empty");
     let cc = graph.get_connected_components();
@@ -363,50 +384,55 @@ fn test_connectivity() {
     assert_eq!(cc_unconnected[0].len(), 34);
     assert_eq!(cc_unconnected[1].len(), 2);
     assert_eq!(cc_unconnected.len(), 2);
-    assert!(!graph_unconnected.get_is_connected().unwrap());
+    assert!(!graph_unconnected.get_is_connected()?);
     assert_eq!(graph_empty.get_connected_components().len(), 0);
     assert!(graph_empty.get_is_connected().is_err(), "Graph is empty");
+    Ok(())
 }
 
 #[test]
-fn test_betweenness() {
-    let graph = get_karate_club_graph();
-    let bet = graph.get_node_betweenness().unwrap();
+fn test_betweenness() -> CLQResult<()> {
+    let graph = get_karate_club_graph()?;
+    let bet = graph.get_node_betweenness()?;
     assert_eq!(bet[&NodeId::from(8 as i64)], 0.0);
     assert!((bet[&NodeId::from(34 as i64)] - 160.5515873).abs() <= 0.000001);
     assert!((bet[&NodeId::from(33 as i64)] - 76.6904762).abs() <= 0.000001);
     assert!((bet[&NodeId::from(32 as i64)] - 73.0095238).abs() <= 0.000001);
+    Ok(())
 }
 
 #[test]
-fn test_betweenness_brandes() {
-    let graph = get_karate_club_graph();
+fn test_betweenness_brandes() -> CLQResult<()> {
+    let graph = get_karate_club_graph()?;
     let bet = graph.get_node_betweenness_brandes().unwrap();
     assert_eq!(bet[&NodeId::from(8 as i64)], 0.0);
     assert!((bet[&NodeId::from(34 as i64)] - 160.5515873).abs() <= 0.000001);
     assert!((bet[&NodeId::from(33 as i64)] - 76.6904762).abs() <= 0.000001);
     assert!((bet[&NodeId::from(32 as i64)] - 73.0095238).abs() <= 0.000001);
+    Ok(())
 }
 
 #[bench]
-fn bench_betweenness(b: &mut Bencher) {
+fn bench_betweenness(b: &mut Bencher) -> CLQResult<()> {
     b.iter(|| {
-        let graph = get_karate_club_graph();
+        let graph = get_karate_club_graph().unwrap();
         let _bet = graph.get_node_betweenness();
     });
+    Ok(())
 }
 
 #[bench]
-fn bench_betweenness_brandes(b: &mut Bencher) {
+fn bench_betweenness_brandes(b: &mut Bencher) -> CLQResult<()> {
     b.iter(|| {
-        let graph = get_karate_club_graph();
+        let graph = get_karate_club_graph().unwrap();
         let _bet = graph.get_node_betweenness_brandes();
     });
+    Ok(())
 }
 
 #[test]
-fn test_matrices() {
-    let graph = get_karate_club_graph();
+fn test_matrices() -> CLQResult<()> {
+    let graph = get_karate_club_graph()?;
     let (deg_mat, _ids) = graph.get_degree_matrix();
     assert_eq!(deg_mat.shape(), (34, 34));
     assert_eq!(deg_mat.row(0)[0], 16.0);
@@ -423,11 +449,12 @@ fn test_matrices() {
     assert_eq!(laplacian.shape(), (34, 34));
     assert_eq!(laplacian.sum(), 0.0);
     assert_eq!(laplacian + adj_mat, deg_mat);
+    Ok(())
 }
 
 #[test]
-fn test_eigen() {
-    let graph = get_karate_club_graph();
+fn test_eigen() -> CLQResult<()> {
+    let graph = get_karate_club_graph()?;
     let fiedler = graph.get_algebraic_connectivity();
     assert!((fiedler - 0.469).abs() <= 0.001);
 
@@ -436,11 +463,12 @@ fn test_eigen() {
     assert!((ev[&NodeId::from(34 as i64)] - 1.0).abs() <= eps);
     assert!((ev[&NodeId::from(1 as i64)] - 0.95213237).abs() <= eps);
     assert!((ev[&NodeId::from(19 as i64)] - 0.27159396).abs() <= eps);
+    Ok(())
 }
 
 #[test]
-fn test_k_cores() {
-    let graph = get_karate_club_graph();
+fn test_k_cores() -> CLQResult<()> {
+    let graph = get_karate_club_graph()?;
     let k_cores = graph.get_k_cores(1);
     assert_eq!(k_cores.len(), 1);
     assert_eq!(k_cores[0].len(), 34);
@@ -450,7 +478,7 @@ fn test_k_cores() {
     let k_cores_5 = graph.get_k_cores(5);
     assert_eq!(k_cores_5.len(), 0);
 
-    let double_karate = get_two_karate_clubs_with_bridge();
+    let double_karate = get_two_karate_clubs_with_bridge()?;
     let k_cores_4_2 = double_karate.get_k_cores(4);
     assert_eq!(k_cores_4_2.len(), 2);
     assert_eq!(k_cores_4_2[0].len(), 10);
@@ -463,25 +491,27 @@ fn test_k_cores() {
     assert_eq!(core_assignments[3][0].len(), 10);
 
     assert_eq!(coreness[&NodeId::from(34 as i64)], 4);
+    Ok(())
 }
 
 #[test]
-fn test_connected_components() {
-    let graph = get_karate_club_graph();
+fn test_connected_components() -> CLQResult<()> {
+    let graph = get_karate_club_graph()?;
     let conn_comp = graph.get_connected_components();
     assert_eq!(conn_comp.len(), 1);
     assert_eq!(conn_comp[0].len(), 34);
 
-    let double_karate = get_two_karate_clubs();
+    let double_karate = get_two_karate_clubs()?;
     let conn_comp_2 = double_karate.get_connected_components();
     assert_eq!(conn_comp_2.len(), 2);
     assert_eq!(conn_comp_2[0].len(), 34);
     assert_eq!(conn_comp_2[1].len(), 34);
+    Ok(())
 }
 
 #[test]
-fn test_transitivity() {
-    let graph = get_karate_club_graph();
+fn test_transitivity() -> CLQResult<()> {
+    let graph = get_karate_club_graph()?;
     let trans = graph.get_transitivity();
     println!("{}", trans);
     assert!((trans - 0.2556818181818182).abs() <= f64::EPSILON);
@@ -489,10 +519,11 @@ fn test_transitivity() {
     let approx_trans = graph.get_approx_transitivity(1000);
     println!("{}", approx_trans);
     assert!((approx_trans - trans).abs() <= 0.05);
+    Ok(())
 }
 
 #[test]
-fn test_cnm_community() {
+fn test_cnm_community() -> CLQResult<()> {
     let expected: Vec<f64> = vec![
         0.012163050624589085,
         0.023668639053254437,
@@ -527,7 +558,7 @@ fn test_cnm_community() {
         0.004684418145956606,
     ];
 
-    let g = get_karate_club_graph();
+    let g = get_karate_club_graph()?;
     let (_, modularity_changes) = g.get_cnm_communities();
     for i in 0..expected.len() {
         println!(
@@ -536,10 +567,11 @@ fn test_cnm_community() {
         );
         assert!((modularity_changes[i] - expected[i]).abs() <= 0.001);
     }
+    Ok(())
 }
 
 #[test]
-fn test_brokerage() {
+fn test_brokerage() -> CLQResult<()> {
     let expected_counts = vec![
         (0, 0, 0, 0, 0, 0),
         (0, 0, 0, 0, 0, 0),
@@ -577,7 +609,7 @@ fn test_brokerage() {
         (0, 0, 0, 1, 0, 1),
         (0, 0, 0, 0, 0, 0),
     ];
-    let g = get_directed_karate_club_graph();
+    let g = get_directed_karate_club_graph()?;
     let mut c: HashMap<NodeId, usize> = HashMap::new();
     for node_id in g.get_ids_iter() {
         c.insert(*node_id, 1 + ((node_id.value() <= 17) as usize));
@@ -609,20 +641,22 @@ fn test_brokerage() {
             expected_counts[node_id.value() as usize].4
         );
     }
+    Ok(())
 }
 #[test]
-fn test_weakly_connected_components() {
-    let gd = get_directed_karate_club_graph();
+fn test_weakly_connected_components() -> CLQResult<()> {
+    let gd = get_directed_karate_club_graph()?;
     let cc = gd.get_weakly_connected_components();
     assert_eq!(cc[0].len(), 34);
     assert_eq!(cc.len(), 1);
+    Ok(())
 }
 #[test]
-fn test_connectivity_directed() {
-    let graph = get_directed_karate_club_graph();
-    assert!(graph.get_is_weakly_connected().unwrap());
-    let graph_unconnected = get_directed_karate_club_graph_with_one_extra_edge();
-    assert!(!graph_unconnected.get_is_weakly_connected().unwrap());
+fn test_connectivity_directed() -> CLQResult<()> {
+    let graph = get_directed_karate_club_graph()?;
+    assert!(graph.get_is_weakly_connected()?);
+    let graph_unconnected = get_directed_karate_club_graph_with_one_extra_edge()?;
+    assert!(!graph_unconnected.get_is_weakly_connected()?);
 
     let graph_empty = SimpleDirectedGraph::create_empty();
     assert!(
@@ -635,12 +669,12 @@ fn test_connectivity_directed() {
         graph.count_nodes()
     );
 
-    let graph_both_ways = get_directed_karate_club_graph_both_ways();
+    let graph_both_ways = get_directed_karate_club_graph_both_ways()?;
     assert_eq!(graph_both_ways.get_strongly_connected_components().len(), 1);
 
     let core = vec![1, 2, 3];
     let graph_with_core =
-        get_directed_karate_club_graph_with_core(core.into_iter().collect::<HashSet<usize>>());
+        get_directed_karate_club_graph_with_core(core.into_iter().collect::<HashSet<usize>>())?;
     let scc = graph_with_core.get_strongly_connected_components();
     assert_eq!(scc.len(), 32);
     assert_eq!(scc[0].len(), 3);
@@ -656,34 +690,36 @@ fn test_connectivity_directed() {
         .iter()
         .collect::<HashSet<&NodeId>>()
         .contains(&NodeId::from(3)));
+    Ok(())
 }
 #[test]
-fn test_acyclic_directed() {
-    let graph = get_directed_karate_club_graph();
+fn test_acyclic_directed() -> CLQResult<()> {
+    let graph = get_directed_karate_club_graph()?;
     assert!(graph.is_acyclic());
-    let graph_unconnected = get_directed_karate_club_graph_with_one_extra_edge();
+    let graph_unconnected = get_directed_karate_club_graph_with_one_extra_edge()?;
     assert!(graph_unconnected.is_acyclic());
 
     let graph_empty = SimpleDirectedGraph::create_empty();
     assert!(graph_empty.is_acyclic());
 
-    let graph_both_ways = get_directed_karate_club_graph_both_ways();
+    let graph_both_ways = get_directed_karate_club_graph_both_ways()?;
     assert!(!graph_both_ways.is_acyclic());
 
     let core = vec![1, 2, 3];
     let graph_with_core =
-        get_directed_karate_club_graph_with_core(core.into_iter().collect::<HashSet<usize>>());
+        get_directed_karate_club_graph_with_core(core.into_iter().collect::<HashSet<usize>>())?;
     assert!(!graph_with_core.is_acyclic());
+    Ok(())
 }
 
 #[test]
-fn test_clique_seeding() {
+fn test_clique_seeding() -> CLQResult<()> {
     let clique = vec![1, 2, 3, 4, 5];
     let cliques = vec![clique
         .into_iter()
         .map(|x| NodeId::from(x))
         .collect::<BTreeSet<_>>()];
-    let g = get_karate_club_graph_with_cliques(cliques);
+    let g = get_karate_club_graph_with_cliques(cliques)?;
     // adding 3 edges, from 2 -> 5, 3, -> 5, 4 -> 5
     assert_eq!(g.count_edges(), 81);
 
@@ -699,7 +735,8 @@ fn test_clique_seeding() {
             .map(|x| NodeId::from(x))
             .collect::<BTreeSet<_>>(),
     ];
-    let g = get_karate_club_graph_with_cliques(cliques);
+    let g = get_karate_club_graph_with_cliques(cliques)?;
     // adding 5 edges, from 2 -> 5, 3, -> 5, 4 -> 5, 5 -> 6
     assert_eq!(g.count_edges(), 82);
+    Ok(())
 }

--- a/tests/karate_club.rs
+++ b/tests/karate_club.rs
@@ -121,10 +121,7 @@ fn get_karate_club_edges() -> Vec<(usize, usize)> {
     ]
 }
 fn _get_karate_club_graph_with_one_extra_edge<T, R>(builder: T) -> R
-where
-    R: GraphBase,
-    T: GraphBuilderBase<GraphType = R>,
-{
+where R: GraphBase, T: GraphBuilderBase<GraphType = R, RowType = (i64, i64)> {
     let mut rows = get_karate_club_edges();
     rows.push((35, 36));
     builder.from_vector(
@@ -152,10 +149,7 @@ fn get_two_karate_clubs_edges() -> Vec<(usize, usize)> {
 }
 
 fn _get_two_karate_clubs<T, R>(builder: T) -> R
-where
-    R: GraphBase,
-    T: GraphBuilderBase<GraphType = R>,
-{
+where R: GraphBase, T: GraphBuilderBase<GraphType = R, RowType = (i64, i64)> {
     let rows = get_two_karate_clubs_edges();
     builder.from_vector(
         &rows
@@ -204,10 +198,7 @@ fn get_directed_karate_club_graph_with_core(core: HashSet<usize>) -> SimpleDirec
 }
 
 fn _get_two_karate_clubs_with_bridge<T, R>(builder: T) -> R
-where
-    R: GraphBase,
-    T: GraphBuilderBase<GraphType = R>,
-{
+where R: GraphBase, T: GraphBuilderBase<GraphType = R, RowType = (i64, i64)> {
     let mut rows = get_two_karate_clubs_edges();
     rows.push((34, 35));
     builder.from_vector(
@@ -223,10 +214,7 @@ fn get_two_karate_clubs_with_bridge() -> SimpleUndirectedGraph {
 }
 
 fn _get_karate_club_graph<T, R>(builder: T) -> R
-where
-    R: GraphBase,
-    T: GraphBuilderBase<GraphType = R>,
-{
+where R: GraphBase, T: GraphBuilderBase<GraphType = R, RowType = (i64, i64)> {
     let rows = get_karate_club_edges();
     builder.from_vector(
         &rows

--- a/tests/pruning.rs
+++ b/tests/pruning.rs
@@ -37,8 +37,7 @@ fn simple_test(raw: Vec<String>, min_degree: usize, expected_len: usize) -> CLQR
     let transformer = gen_test_transformer(typespec, "author".to_string())?;
     let rows = process_raw_vector(&transformer, raw)?;
 
-    let mut graph: TypedGraph =
-        transformer.build_pruned_graph(graph_id, &rows)?;
+    let mut graph: TypedGraph = transformer.build_pruned_graph(graph_id, &rows)?;
     let exclude_nodes: HashSet<NodeId> =
         TypedGraphBuilder::trim_edges(&mut graph.nodes, &min_degree);
     assert_eq!(exclude_nodes.len(), expected_len);
@@ -97,8 +96,7 @@ fn test_prune_small_clique() -> CLQResult<()> {
 
     let transformer = gen_test_transformer(ts, "author".to_string())?;
     let rows = process_raw_vector(&transformer, raw)?;
-    let mut graph: TypedGraph =
-        transformer.build_pruned_graph(graph_id, &rows)?;
+    let mut graph: TypedGraph = transformer.build_pruned_graph(graph_id, &rows)?;
     assert_eq!(graph.nodes.len(), 5);
     graph = TypedGraphBuilder::prune(graph, &rows, 2)?;
     assert_eq!(graph.nodes.len(), 4);
@@ -152,17 +150,10 @@ fn test_full_prune_small_clique() -> CLQResult<()> {
     )?;
     let rows_prune = process_raw_vector(&transformer_prune, raw.clone())?;
 
-    let graph: TypedGraph = transformer_prune
-        .build_pruned_graph(graph_id, &rows_prune)?;
+    let graph: TypedGraph = transformer_prune.build_pruned_graph(graph_id, &rows_prune)?;
     let v_prune = Vec::new();
     let result_prune = transformer_prune
-        .process_clique_rows(
-            &graph,
-            &v_prune,
-            graph_id,
-            false,
-            &sender_prune,
-        )?
+        .process_clique_rows(&graph, &v_prune, graph_id, false, &sender_prune)?
         .ok_or_else(CLQError::err_none)?;
     sender_prune.send((None, true)).unwrap();
     let candidate_prune = result_prune.top_candidate;
@@ -187,8 +178,7 @@ fn test_full_prune_small_clique() -> CLQResult<()> {
     )?;
     let rows = process_raw_vector(&transformer, raw)?;
 
-    let graph: TypedGraph =
-        transformer.build_pruned_graph(graph_id, &rows)?;
+    let graph: TypedGraph = transformer.build_pruned_graph(graph_id, &rows)?;
     let v = Vec::new();
     let result = transformer
         .process_clique_rows(&graph, &v, graph_id, false, &sender)?

--- a/tests/pruning.rs
+++ b/tests/pruning.rs
@@ -7,7 +7,6 @@
 extern crate lib_dachshund;
 use lib_dachshund::dachshund::candidate::Candidate;
 use lib_dachshund::dachshund::error::{CLQError, CLQResult};
-use lib_dachshund::dachshund::graph_builder::GraphBuilder;
 use lib_dachshund::dachshund::id_types::{GraphId, NodeId};
 use lib_dachshund::dachshund::test_utils::{
     assert_nodes_have_ids, gen_test_transformer, process_raw_vector,
@@ -39,7 +38,7 @@ fn simple_test(raw: Vec<String>, min_degree: usize, expected_len: usize) -> CLQR
     let rows = process_raw_vector(&transformer, raw)?;
 
     let mut graph: TypedGraph =
-        transformer.build_pruned_graph::<TypedGraphBuilder, TypedGraph>(graph_id, &rows)?;
+        transformer.build_pruned_graph(graph_id, &rows)?;
     let exclude_nodes: HashSet<NodeId> =
         TypedGraphBuilder::trim_edges(&mut graph.nodes, &min_degree);
     assert_eq!(exclude_nodes.len(), expected_len);
@@ -99,13 +98,13 @@ fn test_prune_small_clique() -> CLQResult<()> {
     let transformer = gen_test_transformer(ts, "author".to_string())?;
     let rows = process_raw_vector(&transformer, raw)?;
     let mut graph: TypedGraph =
-        transformer.build_pruned_graph::<TypedGraphBuilder, TypedGraph>(graph_id, &rows)?;
+        transformer.build_pruned_graph(graph_id, &rows)?;
     assert_eq!(graph.nodes.len(), 5);
     graph = TypedGraphBuilder::prune(graph, &rows, 2)?;
     assert_eq!(graph.nodes.len(), 4);
     let v = Vec::new();
     let res: Candidate<TypedGraph> = transformer
-        .process_graph::<TypedGraph>(&graph, &v, graph_id, true)?
+        .process_graph(&graph, &v, graph_id, true)?
         .top_candidate;
     assert_nodes_have_ids(&graph, &res.core_ids, vec![1, 2], true);
     assert_nodes_have_ids(&graph, &res.non_core_ids, vec![3, 4], false);
@@ -154,10 +153,10 @@ fn test_full_prune_small_clique() -> CLQResult<()> {
     let rows_prune = process_raw_vector(&transformer_prune, raw.clone())?;
 
     let graph: TypedGraph = transformer_prune
-        .build_pruned_graph::<TypedGraphBuilder, TypedGraph>(graph_id, &rows_prune)?;
+        .build_pruned_graph(graph_id, &rows_prune)?;
     let v_prune = Vec::new();
     let result_prune = transformer_prune
-        .process_clique_rows::<TypedGraphBuilder, TypedGraph>(
+        .process_clique_rows(
             &graph,
             &v_prune,
             graph_id,
@@ -189,10 +188,10 @@ fn test_full_prune_small_clique() -> CLQResult<()> {
     let rows = process_raw_vector(&transformer, raw)?;
 
     let graph: TypedGraph =
-        transformer.build_pruned_graph::<TypedGraphBuilder, TypedGraph>(graph_id, &rows)?;
+        transformer.build_pruned_graph(graph_id, &rows)?;
     let v = Vec::new();
     let result = transformer
-        .process_clique_rows::<TypedGraphBuilder, TypedGraph>(&graph, &v, graph_id, false, &sender)?
+        .process_clique_rows(&graph, &v, graph_id, false, &sender)?
         .ok_or_else(CLQError::err_none)?;
     sender.send((None, true)).unwrap();
     let candidate = result.top_candidate;

--- a/tests/scoring.rs
+++ b/tests/scoring.rs
@@ -16,7 +16,6 @@ use lib_dachshund::dachshund::scorer::Scorer;
 use lib_dachshund::dachshund::search_problem::SearchProblem;
 use lib_dachshund::dachshund::transformer::Transformer;
 use lib_dachshund::dachshund::typed_graph::TypedGraph;
-use lib_dachshund::dachshund::typed_graph_builder::TypedGraphBuilder;
 
 use lib_dachshund::dachshund::test_utils::{gen_test_transformer, process_raw_vector};
 
@@ -36,7 +35,7 @@ fn test_score_trivial_graph() -> CLQResult<()> {
     let transformer: Transformer = gen_test_transformer(typespec, "author".to_string())?;
     let rows: Vec<EdgeRow> = process_raw_vector(&transformer, raw)?;
     let graph: TypedGraph =
-        transformer.build_pruned_graph::<TypedGraphBuilder, TypedGraph>(graph_id, &rows)?;
+        transformer.build_pruned_graph(graph_id, &rows)?;
     assert_eq!(graph.core_ids.len(), 1);
     assert_eq!(graph.non_core_ids.len(), 1);
 

--- a/tests/scoring.rs
+++ b/tests/scoring.rs
@@ -34,8 +34,7 @@ fn test_score_trivial_graph() -> CLQResult<()> {
     let raw: Vec<String> = vec!["0\t1\t2\tauthor\tpublished_at\tconference".to_string()];
     let transformer: Transformer = gen_test_transformer(typespec, "author".to_string())?;
     let rows: Vec<EdgeRow> = process_raw_vector(&transformer, raw)?;
-    let graph: TypedGraph =
-        transformer.build_pruned_graph(graph_id, &rows)?;
+    let graph: TypedGraph = transformer.build_pruned_graph(graph_id, &rows)?;
     assert_eq!(graph.core_ids.len(), 1);
     assert_eq!(graph.non_core_ids.len(), 1);
 

--- a/tests/simple_directed_graph.rs
+++ b/tests/simple_directed_graph.rs
@@ -5,12 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 extern crate lib_dachshund;
+use lib_dachshund::dachshund::error::{CLQError, CLQResult};
 use lib_dachshund::dachshund::graph_base::GraphBase;
 use lib_dachshund::dachshund::graph_builder_base::GraphBuilderBase;
 use lib_dachshund::dachshund::simple_directed_graph::SimpleDirectedGraph;
 use lib_dachshund::dachshund::simple_directed_graph_builder::SimpleDirectedGraphBuilder;
 use std::collections::HashSet;
-fn get_rows(idx: usize) -> Result<Vec<(usize, usize)>, String> {
+fn get_rows(idx: usize) -> CLQResult<Vec<(usize, usize)>> {
     match idx {
         0 => Ok(vec![
             (0, 1),
@@ -121,25 +122,25 @@ fn get_rows(idx: usize) -> Result<Vec<(usize, usize)>, String> {
             (20, 22),
             (20, 24),
         ]),
-        _ => return Err("Invalid index".to_string()),
+        _ => return Err(CLQError::Generic("Invalid index".to_string())),
     }
 }
 
-fn get_graph(idx: usize) -> Result<SimpleDirectedGraph, String> {
-    Ok(SimpleDirectedGraphBuilder {}.from_vector(
+fn get_graph(idx: usize) -> CLQResult<SimpleDirectedGraph> {
+    SimpleDirectedGraphBuilder {}.from_vector(
         &get_rows(idx)?
             .into_iter()
             .map(|(x, y)| (x as i64, y as i64))
             .collect(),
-    ))
+    )
 }
 
 #[cfg(test)]
 #[test]
-fn test_build_graph() {
+fn test_build_graph() -> CLQResult<()> {
     for i in 0..7 {
-        let rows = get_rows(i).unwrap();
-        let graph = get_graph(i).unwrap();
+        let rows = get_rows(i)?;
+        let graph = get_graph(i)?;
         assert_eq!(rows.len(), graph.count_edges());
         assert_eq!(
             rows.iter()
@@ -150,4 +151,5 @@ fn test_build_graph() {
             graph.count_nodes()
         );
     }
+    Ok(())
 }

--- a/tests/simple_graph.rs
+++ b/tests/simple_graph.rs
@@ -11,6 +11,7 @@ use lib_dachshund::dachshund::algorithms::connected_components::{
     ConnectedComponents, ConnectedComponentsUndirected,
 };
 use lib_dachshund::dachshund::algorithms::coreness::Coreness;
+use lib_dachshund::dachshund::error::{CLQError, CLQResult};
 use lib_dachshund::dachshund::graph_builder_base::GraphBuilderBase;
 use lib_dachshund::dachshund::id_types::NodeId;
 use lib_dachshund::dachshund::input::Input;
@@ -23,7 +24,7 @@ use lib_dachshund::dachshund::simple_undirected_graph_builder::SimpleUndirectedG
 use std::collections::{BTreeSet, HashSet};
 use std::iter::FromIterator;
 
-fn get_graph(idx: usize) -> Result<SimpleUndirectedGraph, String> {
+fn get_graph(idx: usize) -> CLQResult<SimpleUndirectedGraph> {
     let v = match idx {
         0 => vec![
             (0, 1),
@@ -134,10 +135,10 @@ fn get_graph(idx: usize) -> Result<SimpleUndirectedGraph, String> {
             (20, 22),
             (20, 24),
         ],
-        _ => return Err("Invalid index".to_string()),
+        _ => return Err(CLQError::Generic("Invalid index".to_string())),
     };
-    Ok(SimpleUndirectedGraphBuilder {}
-        .from_vector(&v.into_iter().map(|(x, y)| (x as i64, y as i64)).collect()))
+    SimpleUndirectedGraphBuilder {}
+        .from_vector(&v.into_iter().map(|(x, y)| (x as i64, y as i64)).collect())
 }
 fn get_expected_modularity_changes(idx: usize) -> Result<Vec<f64>, String> {
     match idx {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -17,7 +17,6 @@ use lib_dachshund::dachshund::test_utils::{
 };
 use lib_dachshund::dachshund::transformer::Transformer;
 use lib_dachshund::dachshund::typed_graph::TypedGraph;
-use lib_dachshund::dachshund::typed_graph_builder::TypedGraphBuilder;
 use std::sync::mpsc::channel;
 
 #[cfg(test)]
@@ -121,12 +120,12 @@ where
 
     let rows = process_raw_vector(&transformer, raw).unwrap();
     let graph: TypedGraph = transformer
-        .build_pruned_graph::<TypedGraphBuilder, TypedGraph>(graph_id, &rows)
+        .build_pruned_graph(graph_id, &rows)
         .unwrap();
     let clique_rows = Vec::new();
     let (sender, _receiver) = channel();
     let res: Candidate<TypedGraph> = transformer
-        .process_clique_rows::<TypedGraphBuilder, TypedGraph>(
+        .process_clique_rows(
             &graph,
             &clique_rows,
             graph_id,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -119,19 +119,11 @@ where
     let graph_id: GraphId = 0.into();
 
     let rows = process_raw_vector(&transformer, raw).unwrap();
-    let graph: TypedGraph = transformer
-        .build_pruned_graph(graph_id, &rows)
-        .unwrap();
+    let graph: TypedGraph = transformer.build_pruned_graph(graph_id, &rows).unwrap();
     let clique_rows = Vec::new();
     let (sender, _receiver) = channel();
     let res: Candidate<TypedGraph> = transformer
-        .process_clique_rows(
-            &graph,
-            &clique_rows,
-            graph_id,
-            true,
-            &sender,
-        )
+        .process_clique_rows(&graph, &clique_rows, graph_id, true, &sender)
         .unwrap()
         .ok_or_else(CLQError::err_none)
         .unwrap()

--- a/tests/triangles.rs
+++ b/tests/triangles.rs
@@ -11,6 +11,7 @@ extern crate test;
 
 use lib_dachshund::dachshund::algorithms::clustering::Clustering;
 use lib_dachshund::dachshund::algorithms::transitivity::Transitivity;
+use lib_dachshund::dachshund::error::CLQResult;
 use lib_dachshund::dachshund::graph_builder_base::GraphBuilderBase;
 use lib_dachshund::dachshund::id_types::NodeId;
 use lib_dachshund::dachshund::simple_undirected_graph::SimpleUndirectedGraph;
@@ -22,77 +23,83 @@ use test::Bencher;
 
 // The complete graph on 4 nodes with one edge removed.
 // This is the minimal counterexample where T(G) != C(G).
-fn get_almost_k4_graph() -> SimpleUndirectedGraph {
+fn get_almost_k4_graph() -> CLQResult<SimpleUndirectedGraph> {
     let v = vec![(0, 1), (0, 2), (0, 3), (1, 2), (1, 3)];
     SimpleUndirectedGraphBuilder {}
         .from_vector(&v.into_iter().map(|(x, y)| (x as i64, y as i64)).collect())
 }
 
 #[test]
-fn test_triangle_count() {
-    let k4 = SimpleUndirectedGraphBuilder {}.get_complete_graph(4);
+fn test_triangle_count() -> CLQResult<()> {
+    let k4 = SimpleUndirectedGraphBuilder {}.get_complete_graph(4)?;
     for node_id in k4.nodes.keys() {
         assert_eq!(3, k4.triangle_count(*node_id));
     }
 
-    let almost_k4 = get_almost_k4_graph();
+    let almost_k4 = get_almost_k4_graph()?;
     for i in 0..4 {
         let id = NodeId::from(i as i64);
         assert_eq!(if i <= 1 { 2 } else { 1 }, almost_k4.triangle_count(id));
     }
+    Ok(())
 }
 
 #[bench]
-fn bench_triangle_count(b: &mut Bencher) {
-    let k100 = SimpleUndirectedGraphBuilder {}.get_complete_graph(100);
+fn bench_triangle_count(b: &mut Bencher) -> CLQResult<()> {
+    let k100 = SimpleUndirectedGraphBuilder {}.get_complete_graph(100)?;
     b.iter(|| {
         for node_id in k100.nodes.keys() {
             k100.triangle_count(*node_id);
         }
     });
+    Ok(())
 }
 
 #[test]
-fn test_clustering_coefficient() {
-    let k4 = &SimpleUndirectedGraphBuilder {}.get_complete_graph(4);
+fn test_clustering_coefficient() -> CLQResult<()> {
+    let k4 = &SimpleUndirectedGraphBuilder {}.get_complete_graph(4)?;
     for node_id in k4.nodes.keys() {
         assert_eq!(1.0, k4.get_clustering_coefficient(*node_id).unwrap());
     }
     assert_eq!(1.0, k4.get_avg_clustering());
 
-    let almost_k4 = &get_almost_k4_graph();
+    let almost_k4 = &get_almost_k4_graph()?;
 
     assert!(((5 as f64 / 6 as f64) - almost_k4.get_avg_clustering()).abs() <= 0.00001);
+    Ok(())
 }
 
 #[test]
-fn test_transitivity() {
-    let k4 = &SimpleUndirectedGraphBuilder {}.get_complete_graph(4);
+fn test_transitivity() -> CLQResult<()> {
+    let k4 = &SimpleUndirectedGraphBuilder {}.get_complete_graph(4)?;
     assert_eq!(1.0, k4.get_transitivity());
 
-    let almost_k4 = &get_almost_k4_graph();
+    let almost_k4 = &get_almost_k4_graph()?;
     assert_eq!(0.75, almost_k4.get_transitivity());
+    Ok(())
 }
 
 #[test]
-fn test_approx_avg_clustering() {
-    let k4 = &SimpleUndirectedGraphBuilder {}.get_complete_graph(4);
+fn test_approx_avg_clustering() -> CLQResult<()> {
+    let k4 = &SimpleUndirectedGraphBuilder {}.get_complete_graph(4)?;
     assert_eq!(1.0, k4.get_approx_avg_clustering(10));
 
-    let almost_k4 = &get_almost_k4_graph();
+    let almost_k4 = &get_almost_k4_graph()?;
     let approx_clustering = almost_k4.get_approx_avg_clustering(100000);
     assert!(((5 as f64 / 6 as f64) - approx_clustering).abs() <= 0.01);
+    Ok(())
 }
 
 #[test]
-fn test_approx_transitivity() {
-    let k4 = &SimpleUndirectedGraphBuilder {}.get_complete_graph(4);
+fn test_approx_transitivity() -> CLQResult<()> {
+    let k4 = &SimpleUndirectedGraphBuilder {}.get_complete_graph(4)?;
     assert_eq!(1.0, k4.get_approx_transitivity(10));
 
-    let almost_k4 = &get_almost_k4_graph();
+    let almost_k4 = &get_almost_k4_graph()?;
     let approx_transitivity = almost_k4.get_approx_transitivity(100000);
 
     println!("{}", approx_transitivity);
 
     assert!((0.75 - approx_transitivity).abs() <= 0.01);
+    Ok(())
 }


### PR DESCRIPTION
This is a major milestone, which unifies the creation of `SimpleUndirectedGraph`, `SimpleDirectedGraph`, and `TypedGraph` under a single builder trait. Getting here required a few things:
- changing the `GraphBuilder` trait to return a `CLQResult` and fixing simple graph tests accordingly.
- adding a few arguments to `TypedGraphBuilder` that were previously in the ill-named `new` function (which was *not* a constructor).
- changing the `Transformer` class to use the call to `from_vector` from `TypedGraphBuilder`.
- removing the crufty templated functions from `Transformer`. In the future we can rely on associated types for a much cleaner implementation of that functionality. Suffice to say I did not quite know what I was doing when I had refactored `Transformer` last.