### PR TITLE
Clippy fixes; use 2021 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@
 name = "dachshund"
 description = "Dachshund is a graph mining library written in Rust. It provides high performance data structures for multiple kinds of graphs, from simple undirected graphs to typed hypergraphs. Dachshund also provides algorithms for common tasks for graph mining and analysis, ranging from shortest paths to graph spectral analysis."
 version = "0.1.8"
-edition = "2018"
+edition = "2021"
 repository = "https://github.com/facebookresearch/dachshund"
 license = "MIT"
 keywords = ["graph", "network"]

--- a/src/dachshund/algorithms/betweenness.rs
+++ b/src/dachshund/algorithms/betweenness.rs
@@ -80,7 +80,7 @@ pub trait Betweenness:
                 let w = stack.pop().unwrap();
                 for pred in &preds[&w] {
                     *dependencies.entry(*pred).or_insert(0.0) += (0.5 + dependencies[&w])
-                        * (shortest_path_counts[&pred] as f64 / shortest_path_counts[&w] as f64)
+                        * (shortest_path_counts[pred] as f64 / shortest_path_counts[&w] as f64)
                 }
                 if w != *source {
                     *betweenness.entry(w).or_insert(0.0) += dependencies[&w]

--- a/src/dachshund/algorithms/clustering.rs
+++ b/src/dachshund/algorithms/clustering.rs
@@ -44,9 +44,7 @@ pub trait Clustering:
     fn get_avg_clustering(&self) -> f64 {
         let coefs = self
             .get_ids_iter()
-            .map(|x| self.get_clustering_coefficient(*x))
-            .filter(|x| x.is_some())
-            .map(|x| x.unwrap())
+            .filter_map(|x| self.get_clustering_coefficient(*x))
             .collect::<Vec<f64>>();
         Iterator::sum::<f64>(coefs.iter()) / coefs.len() as f64
     }

--- a/src/dachshund/algorithms/cnm_communities.rs
+++ b/src/dachshund/algorithms/cnm_communities.rs
@@ -126,7 +126,7 @@ pub trait CNMCommunities: GraphBase<NodeType = SimpleNode> {
             for id in community {
                 for e in self.get_node(*id).get_edges() {
                     let neighbor_id = e.get_neighbor_id();
-                    let i: &usize = reverse_id_map.get(&id).unwrap();
+                    let i: &usize = reverse_id_map.get(id).unwrap();
                     let j: &usize = reverse_id_map.get(&neighbor_id).unwrap();
                     let k_i: usize = degree_map[i];
                     let k_j: usize = degree_map[j];

--- a/src/dachshund/algorithms/connectivity.rs
+++ b/src/dachshund/algorithms/connectivity.rs
@@ -56,7 +56,7 @@ pub trait Connectivity:
             return Err("Graph is empty");
         }
         let root = self.get_ids_iter().next().unwrap();
-        self.visit_nodes_from_root(&root, &mut visited, &mut Vec::new(), edge_fn);
+        self.visit_nodes_from_root(root, &mut visited, &mut Vec::new(), edge_fn);
         Ok(visited.len() == self.count_nodes())
     }
 }

--- a/src/dachshund/algorithms/k_peaks.rs
+++ b/src/dachshund/algorithms/k_peaks.rs
@@ -35,7 +35,7 @@ pub trait KPeaks: GraphBase + Coreness {
         // If a node is missing from the list of coreness values (not contained in an edge)
         // add a coreness value of 0 to hashmap for that node
         nodes
-            .into_iter()
+            .iter()
             .fold(graph.get_coreness_values(), |mut acc, n_id| {
                 acc.entry(*n_id).or_insert(0);
                 acc
@@ -78,7 +78,7 @@ pub trait KPeaks: GraphBase + Coreness {
                 // For nodes in the k_contour the removal causes its core number to drop to 0,
                 // We check to see if this drop is greater than the drop in core number observed for these
                 // nodes in previous iterations
-                remaining_nodes.remove(&d_id); // Remove the k-contour node and insert peak numbers
+                remaining_nodes.remove(d_id); // Remove the k-contour node and insert peak numbers
                 let curr_core_value = *curr_core_values.get(d_id).unwrap();
                 peak_numbers.entry(*d_id).or_insert(curr_core_value as i32);
                 if let Some(x) = mountain_assignments.get_mut(d_id) {

--- a/src/dachshund/algorithms/shortest_paths.rs
+++ b/src/dachshund/algorithms/shortest_paths.rs
@@ -38,7 +38,7 @@ pub trait ShortestPaths:
             None => self.get_ids_iter().cloned().collect(),
         };
         for id in &targets {
-            queue.insert(&id);
+            queue.insert(id);
             dist.insert(*id, None);
             parents.insert(*id, HashSet::new());
         }
@@ -50,9 +50,11 @@ pub trait ShortestPaths:
             // find next node u to visit
             for maybe_u in &queue {
                 let d: Option<usize> = dist[maybe_u];
-                if d != None && (min_dist == None || d.unwrap() < min_dist.unwrap()) {
-                    min_dist = Some(d.unwrap());
-                    u = Some(maybe_u);
+                if let Some(d) = d {
+                    if min_dist.is_none() || d < min_dist.unwrap() {
+                        min_dist = Some(d);
+                        u = Some(maybe_u);
+                    }
                 }
             }
             // remove u from queue
@@ -61,7 +63,7 @@ pub trait ShortestPaths:
                 let v = &e.get_neighbor_id();
                 if queue.contains(v) {
                     let alt = min_dist.unwrap() + 1;
-                    if dist[v] == None || alt <= dist[v].unwrap() {
+                    if dist[v].is_none() || alt <= dist[v].unwrap() {
                         *dist.get_mut(v).unwrap() = Some(alt);
                         parents.get_mut(v).unwrap().insert(*u.unwrap());
                     }
@@ -154,7 +156,7 @@ pub trait ShortestPaths:
                 nodes_by_distance.get_mut(&d).unwrap().push(*node_id);
             }
         }
-        nodes_by_distance.insert(0 as usize, vec![destination]);
+        nodes_by_distance.insert(0_usize, vec![destination]);
 
         let mut distances: Vec<usize> = nodes_by_distance.keys().cloned().collect::<Vec<usize>>();
         distances.sort();
@@ -166,7 +168,7 @@ pub trait ShortestPaths:
             let nodes: &Vec<NodeId> = nodes_by_distance.get(&d).unwrap();
             for node_id in nodes {
                 let parent_ids = parents.get(node_id).unwrap();
-                let new_paths = self.retrace_parent_paths(node_id, &parent_ids, &paths);
+                let new_paths = self.retrace_parent_paths(node_id, parent_ids, &paths);
                 paths.insert(*node_id, new_paths);
             }
         }

--- a/src/dachshund/beam.rs
+++ b/src/dachshund/beam.rs
@@ -92,8 +92,8 @@ impl<'a, TGraph: LabeledGraph<NodeType = Node>> Beam<'a, TGraph> {
         search_problem: Rc<SearchProblem>,
         graph_id: GraphId,
     ) -> CLQResult<Beam<'a, TGraph>> {
-        let core_ids: &Vec<u32> = &graph.get_core_ids();
-        let non_core_ids: &Vec<u32> = &graph.get_non_core_ids().unwrap();
+        let core_ids: &Vec<u32> = graph.get_core_ids();
+        let non_core_ids: &Vec<u32> = graph.get_non_core_ids().unwrap();
 
         let mut candidates: Vec<Candidate<TGraph>> = Vec::with_capacity(search_problem.beam_size);
         let scorer: Scorer = Scorer::new(num_non_core_types, &search_problem);
@@ -106,8 +106,8 @@ impl<'a, TGraph: LabeledGraph<NodeType = Node>> Beam<'a, TGraph> {
 
         if !clique_rows.is_empty() {
             let init_clique = Candidate::from_clique_rows(clique_rows, graph, &scorer)?;
-            if init_clique != None {
-                candidates.push(init_clique.unwrap());
+            if let Some(init_clique) = init_clique {
+                candidates.push(init_clique);
             }
         }
 

--- a/src/dachshund/candidate.rs
+++ b/src/dachshund/candidate.rs
@@ -164,7 +164,7 @@ where
             }
         }
         // could be that no nodes overlapped
-        if candidate.checksum == None {
+        if candidate.checksum.is_none() {
             return Ok(None);
         }
         let score = scorer.score(&mut candidate)?;
@@ -183,7 +183,7 @@ where
             checksum: self.checksum,
             node_id,
         });
-        if self.checksum != None {
+        if self.checksum.is_some() {
             self.checksum = Some(self.checksum.unwrap().wrapping_add(node_hash));
         } else {
             self.checksum = Some(node_hash);
@@ -262,7 +262,7 @@ where
     pub fn get_score(&self) -> CLQResult<f32> {
         let score = self
             .score
-            .ok_or_else(|| "Tried to get score from an unscored candidate.")?;
+            .ok_or("Tried to get score from an unscored candidate.")?;
         Ok(score)
     }
 
@@ -302,15 +302,15 @@ where
 
         let mut s = String::new();
         s.push_str(&core_ids.len().to_string());
-        s.push_str("\t");
+        s.push('\t');
         s.push_str(&non_core_ids.len().to_string());
-        s.push_str("\t");
+        s.push('\t');
 
         s.push_str(&serde_json::to_string(&core_ids).or_else(encode_err_handler)?);
-        s.push_str("\t");
+        s.push('\t');
 
         s.push_str(&serde_json::to_string(&non_core_ids).or_else(encode_err_handler)?);
-        s.push_str("\t");
+        s.push('\t');
 
         let non_core_types_str: Vec<String> = self
             .non_core_ids
@@ -319,11 +319,11 @@ where
             .map(|id| target_types[self.get_node(id).non_core_type.unwrap().value() - 1].clone())
             .collect();
         s.push_str(&serde_json::to_string(&non_core_types_str).or_else(encode_err_handler)?);
-        s.push_str("\t");
+        s.push('\t');
         s.push_str(&cliqueness.to_string());
-        s.push_str("\t");
+        s.push('\t');
         s.push_str(&serde_json::to_string(&self.get_core_densities()).or_else(encode_err_handler)?);
-        s.push_str("\t");
+        s.push('\t');
         s.push_str(
             &serde_json::to_string(&self.get_non_core_densities(target_types.len())?)
                 .or_else(encode_err_handler)?,
@@ -456,11 +456,9 @@ where
             let heap_element = (Reverse(num_ties), node_id);
             if h.len() < num_to_search {
                 h.push(heap_element);
-            } else {
-                if heap_element < *h.peek().unwrap() {
-                    h.pop();
-                    h.push(heap_element);
-                }
+            } else if heap_element < *h.peek().unwrap() {
+                h.pop();
+                h.push(heap_element);
             }
         }
 
@@ -648,11 +646,11 @@ where
         match self.recipe {
             None => self.neighborhood = Some(self.calculate_neighborhood()),
             Some(Recipe { checksum, node_id }) => {
-                if checksum == None || !hints.contains_key(&checksum.unwrap()) {
+                if checksum.is_none() || !hints.contains_key(&checksum.unwrap()) {
                     self.neighborhood = Some(self.calculate_neighborhood());
                 } else {
                     let hint = hints.get(&checksum.unwrap()).unwrap();
-                    if checksum != hint.checksum || hint.neighborhood == None {
+                    if checksum != hint.checksum || hint.neighborhood.is_none() {
                         self.neighborhood = Some(self.calculate_neighborhood());
                     } else {
                         let mut new_neighborhood = hint.neighborhood.as_ref().unwrap().clone();

--- a/src/dachshund/line_processor.rs
+++ b/src/dachshund/line_processor.rs
@@ -79,7 +79,7 @@ impl LineProcessorBase for WeightedLineProcessor {
         let graph_id = self.record_new_key_or_return_current_one(key);
         let source_id: NodeId = vec[1].parse::<i64>()?.into();
         let target_id: NodeId = vec[2].parse::<i64>()?.into();
-        let weight: f64 = vec[3].parse::<f64>()?.into();
+        let weight: f64 = vec[3].parse::<f64>()?;
         Ok(Box::new(WeightedEdgeRow {
             graph_id,
             source_id,

--- a/src/dachshund/simple_undirected_graph_builder.rs
+++ b/src/dachshund/simple_undirected_graph_builder.rs
@@ -141,9 +141,9 @@ impl GraphBuilderBaseWithPreProcessing for SimpleUndirectedGraphBuilderWithCliqu
         let mut row_set: HashSet<<Self as GraphBuilderBase>::RowType> = data.into_iter().collect();
         for clique in self.get_cliques() {
             for comb in clique.iter().combinations(2) {
-                let id1 = comb.get(0).unwrap().clone();
-                let id2 = comb.get(1).unwrap().clone();
-                for clique_edge in self.get_clique_edges(*id1, *id2).unwrap().into_iter() {
+                let id1 = **comb.get(0).unwrap();
+                let id2 = **comb.get(1).unwrap();
+                for clique_edge in self.get_clique_edges(id1, id2).unwrap().into_iter() {
                     row_set.insert(clique_edge);
                 }
             }

--- a/src/dachshund/test_utils.rs
+++ b/src/dachshund/test_utils.rs
@@ -40,7 +40,7 @@ pub fn gen_test_transformer(
 }
 
 pub fn gen_test_typespec() -> Vec<Vec<String>> {
-    return vec![
+    vec![
         vec![
             "author".to_string(),
             "published_at".into(),
@@ -51,7 +51,7 @@ pub fn gen_test_typespec() -> Vec<Vec<String>> {
             "published_at".into(),
             "journal".into(),
         ],
-    ];
+    ]
 }
 
 pub fn assert_nodes_have_ids<T>(

--- a/src/dachshund/transformer.rs
+++ b/src/dachshund/transformer.rs
@@ -91,11 +91,11 @@ impl Transformer {
         non_core_types: Vec<String>,
     ) -> CLQResult<NonCoreTypeIds> {
         let mut non_core_type_ids = NonCoreTypeIds::new();
-        non_core_type_ids.insert(core_type, NodeTypeId::from(0 as usize));
+        non_core_type_ids.insert(core_type, NodeTypeId::from(0_usize));
 
         let should_be_only_this_core_type = &typespec[0][0].clone();
         for (non_core_type_ix, non_core_type) in non_core_types.iter().enumerate() {
-            non_core_type_ids.insert(&non_core_type, NodeTypeId::from(non_core_type_ix + 1));
+            non_core_type_ids.insert(non_core_type, NodeTypeId::from(non_core_type_ix + 1));
         }
         for item in typespec {
             let core_type = &item[0];

--- a/src/dachshund/transformer_base.rs
+++ b/src/dachshund/transformer_base.rs
@@ -38,7 +38,7 @@ pub trait TransformerBase {
     fn run(&mut self, input: Input, mut output: Output) -> CLQResult<()> {
         let ret = crossbeam::scope(|scope| {
             let line_processor = self.get_line_processor();
-            let num_processed = Arc::new(AtomicUsize::new(0 as usize));
+            let num_processed = Arc::new(AtomicUsize::new(0_usize));
             let (sender, receiver) = channel();
             let num_processed_clone = num_processed.clone();
             let writer = scope.spawn(move |_| loop {

--- a/src/dachshund/typed_graph_builder.rs
+++ b/src/dachshund/typed_graph_builder.rs
@@ -205,7 +205,7 @@ pub trait TypedGraphBuilderBase {
     /// new graph, where all nodes are assured to have degree at least min_degree.
     /// The provision of a <Self as GraphBuilderBase>::GraphType is necessary, since the notion of "degree" does
     /// not make sense outside of a graph.
-    fn prune(graph: TypedGraph, rows: &Vec<EdgeRow>, min_degree: usize) -> CLQResult<TypedGraph> {
+    fn prune(graph: TypedGraph, rows: &[EdgeRow], min_degree: usize) -> CLQResult<TypedGraph> {
         let mut target_type_ids: HashMap<NodeLabel, NodeTypeId> = HashMap::new();
         for r in rows.iter() {
             target_type_ids.insert(r.target_id, r.target_type_id);
@@ -231,7 +231,7 @@ pub trait TypedGraphBuilderBase {
     fn get_filtered_sources_targets_rows(
         mut graph: TypedGraph,
         min_degree: usize,
-        rows: &Vec<EdgeRow>,
+        rows: &[EdgeRow],
     ) -> (Vec<NodeLabel>, Vec<NodeLabel>, Vec<EdgeRow>) {
         let exclude_nodes: HashSet<u32> = Self::trim_edges(graph.get_mut_nodes(), &min_degree);
         let filtered_source_ids: Vec<NodeLabel> = graph

--- a/src/dachshund/typed_graph_line_processor.rs
+++ b/src/dachshund/typed_graph_line_processor.rs
@@ -68,13 +68,12 @@ impl LineProcessorBase for TypedGraphLineProcessor {
         let graph_id: GraphId = vec[0].parse::<i64>()?.into();
         let node_id: NodeId = vec[1].parse::<i64>()?.into();
         let node_type: &str = vec[2].trim_end();
-        let non_core_type: Option<NodeTypeId>;
-        if node_type == self.core_type {
-            non_core_type = None;
+        let non_core_type = if node_type == self.core_type {
+            None
         } else {
             let non_core_type_id: NodeTypeId = *self.non_core_type_ids.require(node_type)?;
-            non_core_type = Some(non_core_type_id);
-        }
+            Some(non_core_type_id)
+        };
         Ok(Box::new(CliqueRow {
             graph_id,
             node_id,

--- a/tests/beam.rs
+++ b/tests/beam.rs
@@ -156,7 +156,7 @@ fn test_init_beam_with_clique_rows_input() -> CLQResult<()> {
         )?;
         let text = raw.join("\n");
         let bytes = text.as_bytes();
-        let input = Input::string(&bytes);
+        let input = Input::string(bytes);
         let mut buffer: Vec<u8> = Vec::new();
         let output = Output::string(&mut buffer);
         transformer.run(input, output)?;
@@ -209,7 +209,7 @@ fn test_init_beam_with_clique_rows_input_one_epoch() -> CLQResult<()> {
     )?;
     let text = raw.join("\n");
     let bytes = text.as_bytes();
-    let input = Input::string(&bytes);
+    let input = Input::string(bytes);
     let mut buffer: Vec<u8> = Vec::new();
     let output = Output::string(&mut buffer);
     transformer.run(input, output)?;
@@ -252,7 +252,7 @@ fn test_beam_with_empty_graph_after_pruning() -> CLQResult<()> {
     )?;
     let text = raw.join("\n");
     let bytes = text.as_bytes();
-    let input = Input::string(&bytes);
+    let input = Input::string(bytes);
     let mut buffer: Vec<u8> = Vec::new();
     let output = Output::string(&mut buffer);
     transformer.run(input, output)?;

--- a/tests/cnm.rs
+++ b/tests/cnm.rs
@@ -34,7 +34,7 @@ fn get_graph(idx: usize) -> CLQResult<SimpleUndirectedGraph> {
 fn get_expected_modularity_changes(idx: usize) -> Result<Vec<f64>, String> {
     match idx {
         3 => Ok(vec![0.1015625, 0.09375, 0.09375, 0.03125]),
-        _ => return Err("Invalid index".to_string()),
+        _ => Err("Invalid index".to_string()),
     }
 }
 

--- a/tests/karate_club.rs
+++ b/tests/karate_club.rs
@@ -253,38 +253,38 @@ fn test_karate_club() -> CLQResult<()> {
     let graph = get_karate_club_graph()?;
     assert_eq!(graph.nodes.len(), 34);
     assert_eq!(graph.count_edges(), 78);
-    assert_eq!(graph.get_node_degree(NodeId::from(1 as i64)), 16);
-    assert_eq!(graph.get_node_degree(NodeId::from(2 as i64)), 9);
-    assert_eq!(graph.get_node_degree(NodeId::from(3 as i64)), 10);
-    assert_eq!(graph.get_node_degree(NodeId::from(27 as i64)), 2);
-    assert_eq!(graph.get_node_degree(NodeId::from(34 as i64)), 17);
+    assert_eq!(graph.get_node_degree(NodeId::from(1_i64)), 16);
+    assert_eq!(graph.get_node_degree(NodeId::from(2_i64)), 9);
+    assert_eq!(graph.get_node_degree(NodeId::from(3_i64)), 10);
+    assert_eq!(graph.get_node_degree(NodeId::from(27_i64)), 2);
+    assert_eq!(graph.get_node_degree(NodeId::from(34_i64)), 17);
 
     assert_eq!(
         graph
-            .get_clustering_coefficient(NodeId::from(1 as i64))
+            .get_clustering_coefficient(NodeId::from(1_i64))
             .unwrap(),
         0.15
     );
     assert!(
         (graph
-            .get_clustering_coefficient(NodeId::from(34 as i64))
+            .get_clustering_coefficient(NodeId::from(34_i64))
             .unwrap()
             - 0.1102941)
             <= 0.00001
     );
     assert_eq!(
         graph
-            .get_clustering_coefficient(NodeId::from(22 as i64))
+            .get_clustering_coefficient(NodeId::from(22_i64))
             .unwrap(),
         1.0
     );
     assert_eq!(
-        graph.get_clustering_coefficient(NodeId::from(12 as i64)),
+        graph.get_clustering_coefficient(NodeId::from(12_i64)),
         None
     );
     assert_eq!(
         graph
-            .get_clustering_coefficient(NodeId::from(10 as i64))
+            .get_clustering_coefficient(NodeId::from(10_i64))
             .unwrap(),
         0.0
     );
@@ -294,24 +294,24 @@ fn test_karate_club() -> CLQResult<()> {
 #[test]
 fn test_shortest_paths() -> CLQResult<()> {
     let graph = get_karate_club_graph()?;
-    let source = NodeId::from(1 as i64);
+    let source = NodeId::from(1_i64);
     let (dist, parents) = graph.get_shortest_paths(source, &None);
-    assert_eq!(dist[&NodeId::from(1 as i64)], Some(0));
-    assert_eq!(parents[&NodeId::from(1 as i64)].len(), 1);
-    assert!(parents[&NodeId::from(1 as i64)].contains(&NodeId::from(1 as i64)));
-    assert_eq!(dist[&NodeId::from(2 as i64)], Some(1));
-    assert_eq!(dist[&NodeId::from(33 as i64)], Some(2));
-    assert_eq!(dist[&NodeId::from(30 as i64)], Some(3));
-    assert!(parents[&NodeId::from(2 as i64)].contains(&NodeId::from(1 as i64)));
-    assert!(parents[&NodeId::from(10 as i64)].contains(&NodeId::from(3 as i64)));
-    assert_eq!(parents[&NodeId::from(10 as i64)].len(), 1);
-    assert!(parents[&NodeId::from(33 as i64)].contains(&NodeId::from(3 as i64)));
-    assert!(parents[&NodeId::from(33 as i64)].contains(&NodeId::from(9 as i64)));
-    assert!(parents[&NodeId::from(33 as i64)].contains(&NodeId::from(32 as i64)));
-    assert_eq!(parents[&NodeId::from(33 as i64)].len(), 3);
-    assert!(parents[&NodeId::from(30 as i64)].contains(&NodeId::from(33 as i64)));
-    assert!(parents[&NodeId::from(30 as i64)].contains(&NodeId::from(34 as i64)));
-    assert_eq!(parents[&NodeId::from(30 as i64)].len(), 2);
+    assert_eq!(dist[&NodeId::from(1_i64)], Some(0));
+    assert_eq!(parents[&NodeId::from(1_i64)].len(), 1);
+    assert!(parents[&NodeId::from(1_i64)].contains(&NodeId::from(1_i64)));
+    assert_eq!(dist[&NodeId::from(2_i64)], Some(1));
+    assert_eq!(dist[&NodeId::from(33_i64)], Some(2));
+    assert_eq!(dist[&NodeId::from(30_i64)], Some(3));
+    assert!(parents[&NodeId::from(2_i64)].contains(&NodeId::from(1_i64)));
+    assert!(parents[&NodeId::from(10_i64)].contains(&NodeId::from(3_i64)));
+    assert_eq!(parents[&NodeId::from(10_i64)].len(), 1);
+    assert!(parents[&NodeId::from(33_i64)].contains(&NodeId::from(3_i64)));
+    assert!(parents[&NodeId::from(33_i64)].contains(&NodeId::from(9_i64)));
+    assert!(parents[&NodeId::from(33_i64)].contains(&NodeId::from(32_i64)));
+    assert_eq!(parents[&NodeId::from(33_i64)].len(), 3);
+    assert!(parents[&NodeId::from(30_i64)].contains(&NodeId::from(33_i64)));
+    assert!(parents[&NodeId::from(30_i64)].contains(&NodeId::from(34_i64)));
+    assert_eq!(parents[&NodeId::from(30_i64)].len(), 2);
 
     let shortest_paths = graph.enumerate_shortest_paths(&dist, &parents, source);
     assert_eq!(shortest_paths.len(), 34);
@@ -327,10 +327,10 @@ fn test_shortest_paths() -> CLQResult<()> {
         }
     }
     assert_eq!(unrolled_paths.len(), 89);
-    assert_eq!(shortest_paths[&NodeId::from(2 as i64)].len(), 1);
-    assert_eq!(shortest_paths[&NodeId::from(2 as i64)][0].len(), 2);
-    assert_eq!(shortest_paths[&NodeId::from(30 as i64)][0].len(), 4);
-    assert_eq!(shortest_paths[&NodeId::from(16 as i64)].len(), 7);
+    assert_eq!(shortest_paths[&NodeId::from(2_i64)].len(), 1);
+    assert_eq!(shortest_paths[&NodeId::from(2_i64)][0].len(), 2);
+    assert_eq!(shortest_paths[&NodeId::from(30_i64)][0].len(), 4);
+    assert_eq!(shortest_paths[&NodeId::from(16_i64)].len(), 7);
     assert!(unrolled_paths.contains("1-9-34-16"));
     assert!(unrolled_paths.contains("1-14-34-16"));
     assert!(unrolled_paths.contains("1-20-34-16"));
@@ -345,7 +345,7 @@ fn test_shortest_paths() -> CLQResult<()> {
 fn bench_shortest_paths(b: &mut Bencher) -> CLQResult<()> {
     b.iter(|| {
         let graph = get_karate_club_graph().unwrap();
-        let source = NodeId::from(1 as i64);
+        let source = NodeId::from(1_i64);
         let (_dist, _parents) = graph.get_shortest_paths(source, &None);
     });
     Ok(())
@@ -355,7 +355,7 @@ fn bench_shortest_paths(b: &mut Bencher) -> CLQResult<()> {
 fn bench_shortest_paths_bfs(b: &mut Bencher) -> CLQResult<()> {
     b.iter(|| {
         let graph = get_karate_club_graph().unwrap();
-        let source = NodeId::from(1 as i64);
+        let source = NodeId::from(1_i64);
         let (_ordered_students, _dist, _preds) = graph.get_shortest_paths_bfs(source);
     });
     Ok(())
@@ -388,10 +388,10 @@ fn test_connectivity() -> CLQResult<()> {
 fn test_betweenness() -> CLQResult<()> {
     let graph = get_karate_club_graph()?;
     let bet = graph.get_node_betweenness()?;
-    assert_eq!(bet[&NodeId::from(8 as i64)], 0.0);
-    assert!((bet[&NodeId::from(34 as i64)] - 160.5515873).abs() <= 0.000001);
-    assert!((bet[&NodeId::from(33 as i64)] - 76.6904762).abs() <= 0.000001);
-    assert!((bet[&NodeId::from(32 as i64)] - 73.0095238).abs() <= 0.000001);
+    assert_eq!(bet[&NodeId::from(8_i64)], 0.0);
+    assert!((bet[&NodeId::from(34_i64)] - 160.5515873).abs() <= 0.000001);
+    assert!((bet[&NodeId::from(33_i64)] - 76.6904762).abs() <= 0.000001);
+    assert!((bet[&NodeId::from(32_i64)] - 73.0095238).abs() <= 0.000001);
     Ok(())
 }
 
@@ -399,10 +399,10 @@ fn test_betweenness() -> CLQResult<()> {
 fn test_betweenness_brandes() -> CLQResult<()> {
     let graph = get_karate_club_graph()?;
     let bet = graph.get_node_betweenness_brandes().unwrap();
-    assert_eq!(bet[&NodeId::from(8 as i64)], 0.0);
-    assert!((bet[&NodeId::from(34 as i64)] - 160.5515873).abs() <= 0.000001);
-    assert!((bet[&NodeId::from(33 as i64)] - 76.6904762).abs() <= 0.000001);
-    assert!((bet[&NodeId::from(32 as i64)] - 73.0095238).abs() <= 0.000001);
+    assert_eq!(bet[&NodeId::from(8_i64)], 0.0);
+    assert!((bet[&NodeId::from(34_i64)] - 160.5515873).abs() <= 0.000001);
+    assert!((bet[&NodeId::from(33_i64)] - 76.6904762).abs() <= 0.000001);
+    assert!((bet[&NodeId::from(32_i64)] - 73.0095238).abs() <= 0.000001);
     Ok(())
 }
 
@@ -454,9 +454,9 @@ fn test_eigen() -> CLQResult<()> {
 
     let eps = 0.001;
     let ev = graph.get_eigenvector_centrality(eps, 1000);
-    assert!((ev[&NodeId::from(34 as i64)] - 1.0).abs() <= eps);
-    assert!((ev[&NodeId::from(1 as i64)] - 0.95213237).abs() <= eps);
-    assert!((ev[&NodeId::from(19 as i64)] - 0.27159396).abs() <= eps);
+    assert!((ev[&NodeId::from(34_i64)] - 1.0).abs() <= eps);
+    assert!((ev[&NodeId::from(1_i64)] - 0.95213237).abs() <= eps);
+    assert!((ev[&NodeId::from(19_i64)] - 0.27159396).abs() <= eps);
     Ok(())
 }
 
@@ -484,7 +484,7 @@ fn test_k_cores() -> CLQResult<()> {
     assert_eq!(core_assignments[2][0].len(), 22);
     assert_eq!(core_assignments[3][0].len(), 10);
 
-    assert_eq!(coreness[&NodeId::from(34 as i64)], 4);
+    assert_eq!(coreness[&NodeId::from(34_i64)], 4);
     Ok(())
 }
 
@@ -711,7 +711,7 @@ fn test_clique_seeding() -> CLQResult<()> {
     let clique = vec![1, 2, 3, 4, 5];
     let cliques = vec![clique
         .into_iter()
-        .map(|x| NodeId::from(x))
+        .map(NodeId::from)
         .collect::<BTreeSet<_>>()];
     let g = get_karate_club_graph_with_cliques(cliques)?;
     // adding 3 edges, from 2 -> 5, 3, -> 5, 4 -> 5
@@ -722,11 +722,11 @@ fn test_clique_seeding() -> CLQResult<()> {
     let cliques = vec![
         clique1
             .into_iter()
-            .map(|x| NodeId::from(x))
+            .map(NodeId::from)
             .collect::<BTreeSet<_>>(),
         clique2
             .into_iter()
-            .map(|x| NodeId::from(x))
+            .map(NodeId::from)
             .collect::<BTreeSet<_>>(),
     ];
     let g = get_karate_club_graph_with_cliques(cliques)?;

--- a/tests/pruning.rs
+++ b/tests/pruning.rs
@@ -19,14 +19,14 @@ use std::collections::HashSet;
 use std::sync::mpsc::channel;
 
 pub fn gen_test_typespec() -> Vec<Vec<String>> {
-    return vec![
+    vec![
         vec!["author".into(), "published_at".into(), "conference".into()],
         vec!["author".into(), "published_at".into(), "journal".into()],
         vec!["author".into(), "reviewed_for".into(), "conference".into()],
         vec!["author".into(), "reviewed_for".into(), "journal".into()],
         vec!["author".into(), "administered".into(), "conference".into()],
         vec!["author".into(), "administered".into(), "journal".into()],
-    ];
+    ]
 }
 fn simple_test(raw: Vec<String>, min_degree: usize, expected_len: usize) -> CLQResult<()> {
     let typespec = vec![
@@ -36,7 +36,7 @@ fn simple_test(raw: Vec<String>, min_degree: usize, expected_len: usize) -> CLQR
     let graph_id: GraphId = 0.into();
 
     let transformer = gen_test_transformer(typespec, "author".to_string())?;
-    let rows = process_raw_vector(&transformer, raw)?.clone();
+    let rows = process_raw_vector(&transformer, raw)?;
 
     let mut graph: TypedGraph = transformer.build_pruned_graph(graph_id, rows)?;
     let exclude_nodes: HashSet<u32> = TypedGraphBuilder::trim_edges(&mut graph.nodes, &min_degree);

--- a/tests/scoring.rs
+++ b/tests/scoring.rs
@@ -63,11 +63,11 @@ fn test_score_trivial_graph() -> CLQResult<()> {
     );
 
     let non_core_diversity_score: f32 = scorer.get_non_core_diversity_score(&candidate)?;
-    let expected_non_core_diversity_score: f32 = (2.0 as f32).ln();
+    let expected_non_core_diversity_score: f32 = 2.0_f32.ln();
     assert_eq!(non_core_diversity_score, expected_non_core_diversity_score);
 
     let local_threshold_score: f32 = scorer.get_local_thresh_score(&mut candidate);
-    let expected_local_threshold_score: f32 = 1.0 as f32;
+    let expected_local_threshold_score: f32 = 1.0_f32;
     assert_eq!(local_threshold_score, expected_local_threshold_score);
 
     // size is 2 since each author could be connected to two types of non_cores
@@ -79,13 +79,13 @@ fn test_score_trivial_graph() -> CLQResult<()> {
 
     // cliqueness should be 0.5 because only half the connections are present.
     let cliqueness: f32 = candidate.get_cliqueness()?;
-    assert_eq!(cliqueness, 0.5 as f32);
+    assert_eq!(cliqueness, 0.5_f32);
 
     let global_threshold_score: f32 = scorer.get_global_thresh_score(cliqueness);
-    assert_eq!(global_threshold_score, 1.0 as f32);
+    assert_eq!(global_threshold_score, 1.0_f32);
 
     let score: f32 = scorer.score(&mut candidate)?;
-    let expected_score: f32 = (1.0 as f32 + graph.core_ids.len() as f32).ln()
+    let expected_score: f32 = (1.0_f32 + graph.core_ids.len() as f32).ln()
         + (non_core_diversity_score + cliqueness * alpha);
     assert_eq!(score, expected_score);
     Ok(())

--- a/tests/simple_directed_graph.rs
+++ b/tests/simple_directed_graph.rs
@@ -122,7 +122,7 @@ fn get_rows(idx: usize) -> CLQResult<Vec<(usize, usize)>> {
             (20, 22),
             (20, 24),
         ]),
-        _ => return Err(CLQError::Generic("Invalid index".to_string())),
+        _ => Err(CLQError::Generic("Invalid index".to_string())),
     }
 }
 

--- a/tests/simple_graph.rs
+++ b/tests/simple_graph.rs
@@ -259,7 +259,7 @@ fn get_expected_modularity_changes(idx: usize) -> Result<Vec<f64>, String> {
             0.020833333333333336,
             0.007812500000000002,
         ]),
-        _ => return Err("Invalid index".to_string()),
+        _ => Err("Invalid index".to_string()),
     }
 }
 
@@ -273,7 +273,7 @@ fn test_truss_graph() {
             ._get_connected_components(
                 None,
                 Some(&HashSet::from_iter(
-                    vec![(NodeId::from(2 as i64), NodeId::from(3 as i64))].into_iter()
+                    vec![(NodeId::from(2_i64), NodeId::from(3_i64))].into_iter()
                 ))
             )
             .len(),
@@ -320,8 +320,8 @@ fn test_coreness() {
     let two_cores = get_graph(3).unwrap().get_k_cores(2);
     let three_cores = get_graph(3).unwrap().get_k_cores(3);
 
-    assert_eq!(*coreness.get(&NodeId::from(2 as i64)).unwrap(), 2);
-    assert_eq!(*coreness.get(&NodeId::from(5 as i64)).unwrap(), 2);
+    assert_eq!(*coreness.get(&NodeId::from(2_i64)).unwrap(), 2);
+    assert_eq!(*coreness.get(&NodeId::from(5_i64)).unwrap(), 2);
 
     // There are 2 connected components in the 2-cores...
     assert_eq!(two_cores.len(), 2);
@@ -380,7 +380,7 @@ fn test_simple_transformer() {
         .join("\n");
 
     let bytes = text.as_bytes();
-    let input = Input::string(&bytes);
+    let input = Input::string(bytes);
     let mut buffer: Vec<u8> = Vec::new();
     let output = Output::string(&mut buffer);
     transformer.run(input, output).unwrap();
@@ -417,7 +417,7 @@ fn test_parallel_transformer() {
         + "\n";
 
     let bytes = text.as_bytes();
-    let input = Input::string(&bytes);
+    let input = Input::string(bytes);
     let mut buffer: Vec<u8> = Vec::new();
     let output = Output::string(&mut buffer);
     transformer.run(input, output).unwrap();
@@ -449,82 +449,82 @@ fn test_k_peaks() {
         get_graph(8).unwrap().get_k_peak_mountain_assignment();
 
     // Make sure all peak numbers are correct
-    assert_eq!(*peak_numbers.get(&NodeId::from(0 as i64)).unwrap(), 5);
-    assert_eq!(*peak_numbers.get(&NodeId::from(1 as i64)).unwrap(), 5);
-    assert_eq!(*peak_numbers.get(&NodeId::from(2 as i64)).unwrap(), 5);
-    assert_eq!(*peak_numbers.get(&NodeId::from(3 as i64)).unwrap(), 5);
-    assert_eq!(*peak_numbers.get(&NodeId::from(4 as i64)).unwrap(), 5);
-    assert_eq!(*peak_numbers.get(&NodeId::from(5 as i64)).unwrap(), 5);
-    assert_eq!(*peak_numbers.get(&NodeId::from(13 as i64)).unwrap(), 3);
-    assert_eq!(*peak_numbers.get(&NodeId::from(12 as i64)).unwrap(), 3);
-    assert_eq!(*peak_numbers.get(&NodeId::from(11 as i64)).unwrap(), 3);
-    assert_eq!(*peak_numbers.get(&NodeId::from(10 as i64)).unwrap(), 3);
-    assert_eq!(*peak_numbers.get(&NodeId::from(8 as i64)).unwrap(), 3);
-    assert_eq!(*peak_numbers.get(&NodeId::from(6 as i64)).unwrap(), 1);
-    assert_eq!(*peak_numbers.get(&NodeId::from(7 as i64)).unwrap(), 1);
-    assert_eq!(*peak_numbers.get(&NodeId::from(14 as i64)).unwrap(), 0);
-    assert_eq!(*peak_numbers.get(&NodeId::from(9 as i64)).unwrap(), 0);
+    assert_eq!(*peak_numbers.get(&NodeId::from(0_i64)).unwrap(), 5);
+    assert_eq!(*peak_numbers.get(&NodeId::from(1_i64)).unwrap(), 5);
+    assert_eq!(*peak_numbers.get(&NodeId::from(2_i64)).unwrap(), 5);
+    assert_eq!(*peak_numbers.get(&NodeId::from(3_i64)).unwrap(), 5);
+    assert_eq!(*peak_numbers.get(&NodeId::from(4_i64)).unwrap(), 5);
+    assert_eq!(*peak_numbers.get(&NodeId::from(5_i64)).unwrap(), 5);
+    assert_eq!(*peak_numbers.get(&NodeId::from(13_i64)).unwrap(), 3);
+    assert_eq!(*peak_numbers.get(&NodeId::from(12_i64)).unwrap(), 3);
+    assert_eq!(*peak_numbers.get(&NodeId::from(11_i64)).unwrap(), 3);
+    assert_eq!(*peak_numbers.get(&NodeId::from(10_i64)).unwrap(), 3);
+    assert_eq!(*peak_numbers.get(&NodeId::from(8_i64)).unwrap(), 3);
+    assert_eq!(*peak_numbers.get(&NodeId::from(6_i64)).unwrap(), 1);
+    assert_eq!(*peak_numbers.get(&NodeId::from(7_i64)).unwrap(), 1);
+    assert_eq!(*peak_numbers.get(&NodeId::from(14_i64)).unwrap(), 0);
+    assert_eq!(*peak_numbers.get(&NodeId::from(9_i64)).unwrap(), 0);
 
     // Test mountain configurations
     assert_eq!(
-        mountain_assignments[&0].contains_key(&NodeId::from(0 as i64)),
+        mountain_assignments[&0].contains_key(&NodeId::from(0_i64)),
         true
     );
     assert_eq!(
-        mountain_assignments[&0].contains_key(&NodeId::from(1 as i64)),
+        mountain_assignments[&0].contains_key(&NodeId::from(1_i64)),
         true
     );
     assert_eq!(
-        mountain_assignments[&0].contains_key(&NodeId::from(2 as i64)),
+        mountain_assignments[&0].contains_key(&NodeId::from(2_i64)),
         true
     );
     assert_eq!(
-        mountain_assignments[&0].contains_key(&NodeId::from(3 as i64)),
+        mountain_assignments[&0].contains_key(&NodeId::from(3_i64)),
         true
     );
     assert_eq!(
-        mountain_assignments[&0].contains_key(&NodeId::from(4 as i64)),
+        mountain_assignments[&0].contains_key(&NodeId::from(4_i64)),
         true
     );
     assert_eq!(
-        mountain_assignments[&0].contains_key(&NodeId::from(5 as i64)),
+        mountain_assignments[&0].contains_key(&NodeId::from(5_i64)),
         true
     );
     assert_eq!(
-        mountain_assignments[&0].contains_key(&NodeId::from(6 as i64)),
+        mountain_assignments[&0].contains_key(&NodeId::from(6_i64)),
         true
     );
     assert_eq!(
-        mountain_assignments[&0].contains_key(&NodeId::from(7 as i64)),
+        mountain_assignments[&0].contains_key(&NodeId::from(7_i64)),
         true
     );
     assert_eq!(
-        mountain_assignments[&0].contains_key(&NodeId::from(9 as i64)),
+        mountain_assignments[&0].contains_key(&NodeId::from(9_i64)),
         true
     );
 
     assert_eq!(
-        mountain_assignments[&1].contains_key(&NodeId::from(8 as i64)),
+        mountain_assignments[&1].contains_key(&NodeId::from(8_i64)),
         true
     );
     assert_eq!(
-        mountain_assignments[&1].contains_key(&NodeId::from(10 as i64)),
+        mountain_assignments[&1].contains_key(&NodeId::from(10_i64)),
         true
     );
     assert_eq!(
-        mountain_assignments[&1].contains_key(&NodeId::from(11 as i64)),
+        mountain_assignments[&1].contains_key(&NodeId::from(11_i64)),
         true
     );
     assert_eq!(
-        mountain_assignments[&1].contains_key(&NodeId::from(12 as i64)),
+        mountain_assignments[&1].contains_key(&NodeId::from(12_i64)),
         true
     );
     assert_eq!(
-        mountain_assignments[&1].contains_key(&NodeId::from(13 as i64)),
+        mountain_assignments[&1].contains_key(&NodeId::from(13_i64)),
         true
     );
     assert_eq!(
-        mountain_assignments[&1].contains_key(&NodeId::from(14 as i64)),
+        mountain_assignments[&1].contains_key(&NodeId::from(14_i64)),
         true
     );
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -114,7 +114,7 @@ fn test_process_single_line_clique_row() -> CLQResult<()> {
 
 fn test_expected_clique<F>(transformer: Transformer, raw: Vec<String>, f: F) -> CLQResult<()>
 where
-    F: Fn(&TypedGraph, &Candidate<TypedGraph>) -> (),
+    F: Fn(&TypedGraph, &Candidate<TypedGraph>),
 {
     let graph_id: GraphId = 0.into();
 
@@ -202,7 +202,7 @@ fn test_process_medium_clique() -> CLQResult<()> {
             assert_nodes_have_ids(
                 graph,
                 &res.core_ids,
-                core_ids.iter().map(|x| *x).collect(),
+                core_ids.to_vec(),
                 true,
             );
             assert_nodes_have_ids(

--- a/tests/triangles.rs
+++ b/tests/triangles.rs
@@ -65,7 +65,7 @@ fn test_clustering_coefficient() -> CLQResult<()> {
 
     let almost_k4 = &get_almost_k4_graph()?;
 
-    assert!(((5 as f64 / 6 as f64) - almost_k4.get_avg_clustering()).abs() <= 0.00001);
+    assert!(((5_f64 / 6_f64) - almost_k4.get_avg_clustering()).abs() <= 0.00001);
     Ok(())
 }
 
@@ -86,7 +86,7 @@ fn test_approx_avg_clustering() -> CLQResult<()> {
 
     let almost_k4 = &get_almost_k4_graph()?;
     let approx_clustering = almost_k4.get_approx_avg_clustering(100000);
-    assert!(((5 as f64 / 6 as f64) - approx_clustering).abs() <= 0.01);
+    assert!(((5_f64 / 6_f64) - approx_clustering).abs() <= 0.01);
     Ok(())
 }
 

--- a/tests/weighted_graph.rs
+++ b/tests/weighted_graph.rs
@@ -55,7 +55,7 @@ fn get_graph(idx: usize) -> CLQResult<WeightedUndirectedGraph> {
     };
     WeightedUndirectedGraphBuilder {}.from_vector(
         v.into_iter()
-            .map(|(x, y, z)| (x as i64, y as i64, z as f64))
+            .map(|(x, y, z)| (x as i64, y as i64, z))
             .collect(),
     )
 }
@@ -68,7 +68,7 @@ fn test_node_weight() {
     assert_eq!(weighted_star_graph.nodes.len(), 4);
     assert_eq!(
         weighted_star_graph
-            .get_node(NodeId::from(0 as i64))
+            .get_node(NodeId::from(0_i64))
             .weight(),
         6.0
     );
@@ -76,12 +76,12 @@ fn test_node_weight() {
     // Only a single edge can exist between a pair of nodes (because the graph is not directed).
     // The graph builder should take the weight from the last value.
     let doubled_edge_graph = get_graph(1).unwrap();
-    let node_zero = doubled_edge_graph.get_node(NodeId::from(0 as i64));
+    let node_zero = doubled_edge_graph.get_node(NodeId::from(0_i64));
     assert_eq!(node_zero.edges.len(), 1);
     assert_eq!(node_zero.edges[0].weight, 2.5);
 
     let doubled_edge_graph_two = get_graph(2).unwrap();
-    let node_zero = doubled_edge_graph_two.get_node(NodeId::from(0 as i64));
+    let node_zero = doubled_edge_graph_two.get_node(NodeId::from(0_i64));
     assert_eq!(node_zero.edges.len(), 1);
     assert_eq!(node_zero.edges[0].weight, 0.1);
 }


### PR DESCRIPTION
Hello! Just a few things I've noticed that might help with code quality:
 - Set edition to 2021. Didn't see a MSRV so I just updated y'all from 2018.
 - Ran `cargo +nightly clippy --fix`, which fixed a bunch of lints.
 - Simplified `set_neigbhorhood`<sub>[sic]</sub>`_with_hint` to fix another clippy lint.

Note that there are additional clippy lints but those required more time investment.