### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ version = "^1.0"
 version = "^2.33"
 
 [dependencies.rand]
-version = "^0.6"
+version = "^0.8"
 
 [dependencies.rustc-serialize]
 version = "^0.3"
@@ -46,28 +46,28 @@ version = "^0.3"
 version = "^1.0"
 
 [dependencies.nalgebra]
-version = "0.21.1"
+version = "0.31.4"
 
 [dependencies.rayon]
 version = "1.3.1"
 
 [dependencies.crossbeam]
-version = "0.7.3"
+version = "0.8.2"
 
 [dependencies.ordered-float]
-version = "2.0.0"
+version = "3.4.0"
 
 [dependencies.fxhash]
 version = "0.2.1"
 
 [dependencies.itertools]
-version = "0.9.0"
+version = "0.10.5"
 
 [dependencies.priority-queue]
 version =  "1.1.0"
 
 [dependencies.roaring]
-version = "0.9.0"
+version = "0.10.1"
 
 [[bin]]
 name = "clique_miner"

--- a/src/dachshund/algorithms/clustering.rs
+++ b/src/dachshund/algorithms/clustering.rs
@@ -65,7 +65,7 @@ pub trait Clustering:
 
         for _i in 0..samples {
             // Pick a random node with degree at least 2.
-            let v = &ordered_nodes[rng.gen_range(0, n)];
+            let v = &ordered_nodes[rng.gen_range(0..n)];
 
             // Choose 2 random nodes that are neighbors of j
             let mut random_neighbors = v.get_edges().choose_multiple(&mut rng, 2).into_iter();


### PR DESCRIPTION
Updates outdated dependencies, except for clap which has known breaking changes where I don't know the cli tools enough to know the differences.

Updating `rand` from 0.6 to 0.8 needed a small fix to use a range instead of two values.