### PR TITLE
Replace rustc-serialize with serde_json

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,9 +39,6 @@ version = "^2.33"
 [dependencies.rand]
 version = "^0.6"
 
-[dependencies.rustc-serialize]
-version = "^0.3"
-
 [dependencies.serde_json]
 version = "^1.0"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@
 #![feature(associated_type_bounds)]
 extern crate clap;
 extern crate rand;
-extern crate rustc_serialize;
 extern crate thiserror;
 
 pub mod dachshund;


### PR DESCRIPTION
`rustc-serialize` is deprecated for `serde`, and by extension, `serde_json`.

This PR updates dachshund to serde.