### PR TITLE
Eliminate feature(associated_type_bounds)

### DIFF
--- a/src/dachshund/algorithms/adjacency_matrix.rs
+++ b/src/dachshund/algorithms/adjacency_matrix.rs
@@ -11,8 +11,10 @@ use nalgebra::DMatrix;
 use std::collections::HashMap;
 
 type GraphMatrix = DMatrix<f64>;
-pub trait AdjacencyMatrix:
-    GraphBase<NodeType: NodeBase<NodeIdType = NodeId, NodeEdgeType: NodeEdgeBase<NodeIdType = NodeId>>>
+pub trait AdjacencyMatrix: GraphBase
+where
+    Self::NodeType: NodeBase<NodeIdType = NodeId>,
+    <Self::NodeType as NodeBase>::NodeEdgeType: NodeEdgeBase<NodeIdType = NodeId>,
 {
     fn get_adjacency_matrix_given_node_ids(&self, node_ids: &[NodeId]) -> GraphMatrix {
         let num_nodes = node_ids.len();

--- a/src/dachshund/algorithms/algebraic_connectivity.rs
+++ b/src/dachshund/algorithms/algebraic_connectivity.rs
@@ -6,8 +6,14 @@
  */
 use crate::dachshund::algorithms::laplacian::Laplacian;
 use crate::dachshund::graph_base::GraphBase;
+use crate::dachshund::id_types::NodeId;
+use crate::dachshund::node::{NodeBase, NodeEdgeBase};
 
-pub trait AlgebraicConnectivity: GraphBase + Laplacian {
+pub trait AlgebraicConnectivity: GraphBase + Laplacian
+where
+    Self::NodeType: NodeBase<NodeIdType = NodeId>,
+    <Self::NodeType as NodeBase>::NodeEdgeType: NodeEdgeBase<NodeIdType = NodeId>,
+{
     // Algebraic Connectivity, or the Fiedler Measure, is the second-smallest eigenvalue of the graph Laplacian.
     // The lower the value, the less decomposable the graph's adjacency matrix is. Thanks to the nalgebra
     // crate computing this is quite straightforward.

--- a/src/dachshund/algorithms/betweenness.rs
+++ b/src/dachshund/algorithms/betweenness.rs
@@ -7,11 +7,15 @@
 use crate::dachshund::algorithms::connectivity::{Connectivity, ConnectivityUndirected};
 use crate::dachshund::algorithms::shortest_paths::ShortestPaths;
 use crate::dachshund::id_types::NodeId;
+use crate::dachshund::node::{NodeBase, NodeEdgeBase};
 use crate::dachshund::simple_undirected_graph::UndirectedGraph;
 use std::collections::HashMap;
 
 pub trait Betweenness:
     UndirectedGraph + Connectivity + ShortestPaths + ConnectivityUndirected
+where
+    Self::NodeType: NodeBase<NodeIdType = NodeId>,
+    <Self::NodeType as NodeBase>::NodeEdgeType: NodeEdgeBase<NodeIdType = NodeId>,
 {
     fn get_node_betweenness_starting_from_sources(
         &self,

--- a/src/dachshund/algorithms/brokerage.rs
+++ b/src/dachshund/algorithms/brokerage.rs
@@ -6,7 +6,7 @@
  */
 use crate::dachshund::graph_base::GraphBase;
 use crate::dachshund::id_types::NodeId;
-use crate::dachshund::node::{DirectedNodeBase, NodeEdgeBase};
+use crate::dachshund::node::{DirectedNodeBase, NodeBase, NodeEdgeBase};
 use std::collections::HashMap;
 
 pub struct BrokerageScores {
@@ -18,10 +18,10 @@ pub struct BrokerageScores {
     pub total_open_twopaths: usize,
 }
 
-pub trait Brokerage: GraphBase<NodeType: DirectedNodeBase>
+pub trait Brokerage: GraphBase
 where
-    Self: GraphBase,
-    <Self as GraphBase>::NodeType: DirectedNodeBase,
+    Self::NodeType: DirectedNodeBase,
+    <Self::NodeType as NodeBase>::NodeEdgeType: NodeEdgeBase<NodeIdType = NodeId>,
 {
     fn get_brokerage_scores_for_node(
         &self,

--- a/src/dachshund/algorithms/clustering.rs
+++ b/src/dachshund/algorithms/clustering.rs
@@ -12,14 +12,10 @@ use fxhash::FxHashSet;
 use rand::prelude::*;
 use rand::Rng;
 
-pub trait Clustering:
-    GraphBase<
-    NodeType: NodeBase<
-        NodeIdType = NodeId,
-        NodeEdgeType: NodeEdgeBase<NodeIdType = NodeId>,
-        NodeSetType = FxHashSet<NodeId>,
-    >,
->
+pub trait Clustering: GraphBase
+where
+    Self::NodeType: NodeBase<NodeIdType = NodeId, NodeSetType = FxHashSet<NodeId>>,
+    <Self::NodeType as NodeBase>::NodeEdgeType: NodeEdgeBase<NodeIdType = NodeId>,
 {
     fn get_clustering_coefficient(&self, id: NodeId) -> Option<f64> {
         let node = self.get_node(id);

--- a/src/dachshund/algorithms/connected_components.rs
+++ b/src/dachshund/algorithms/connected_components.rs
@@ -16,14 +16,10 @@ use std::iter::FromIterator;
 
 type OrderedNodeSet = BTreeSet<NodeId>;
 
-pub trait ConnectedComponents:
-    GraphBase<
-    NodeType: NodeBase<
-        NodeIdType = NodeId,
-        NodeEdgeType: NodeEdgeBase<NodeIdType = NodeId>,
-        NodeSetType = FxHashSet<NodeId>,
-    >,
->
+pub trait ConnectedComponents: GraphBase
+where
+    Self::NodeType: NodeBase<NodeIdType = NodeId, NodeSetType = FxHashSet<NodeId>>,
+    <Self::NodeType as NodeBase>::NodeEdgeType: NodeEdgeBase<NodeIdType = NodeId>,
 {
     // returns a hashmap of the form node_id => component_id -- can be turned
     // in to a vector of node_ids inside _get_connected_components.
@@ -92,19 +88,17 @@ pub trait ConnectedComponents:
     }
 }
 
-pub trait ConnectedComponentsUndirected: GraphBase
+pub trait ConnectedComponentsUndirected: GraphBase + ConnectedComponents + UndirectedGraph
 where
-    Self: ConnectedComponents,
-    Self: UndirectedGraph,
+    Self::NodeType: NodeBase<NodeIdType = NodeId, NodeSetType = FxHashSet<NodeId>>,
+    <Self::NodeType as NodeBase>::NodeEdgeType: NodeEdgeBase<NodeIdType = NodeId>,
 {
     fn get_connected_components(&self) -> Vec<Vec<NodeId>> {
         self._get_connected_components(None, None)
     }
 }
-pub trait ConnectedComponentsDirected: GraphBase<NodeType = SimpleDirectedNode>
-where
-    Self: ConnectedComponents,
-    Self: Connectivity,
+pub trait ConnectedComponentsDirected:
+    GraphBase<NodeType = SimpleDirectedNode> + ConnectedComponents + Connectivity
 {
     fn get_weakly_connected_components(&self) -> Vec<Vec<NodeId>> {
         self._get_connected_components(None, None)

--- a/src/dachshund/algorithms/connectivity.rs
+++ b/src/dachshund/algorithms/connectivity.rs
@@ -14,8 +14,10 @@ use std::collections::BTreeSet;
 
 type OrderedNodeSet = BTreeSet<NodeId>;
 
-pub trait Connectivity:
-    GraphBase<NodeType: NodeBase<NodeIdType = NodeId, NodeEdgeType: NodeEdgeBase<NodeIdType = NodeId>>>
+pub trait Connectivity: GraphBase
+where
+    Self::NodeType: NodeBase<NodeIdType = NodeId>,
+    <Self::NodeType as NodeBase>::NodeEdgeType: NodeEdgeBase<NodeIdType = NodeId>,
 {
     fn visit_nodes_from_root<'a>(
         &'a self,
@@ -60,20 +62,21 @@ pub trait Connectivity:
         Ok(visited.len() == self.count_nodes())
     }
 }
-pub trait ConnectivityUndirected: GraphBase
+
+pub trait ConnectivityUndirected: GraphBase + Connectivity + UndirectedGraph
 where
-    Self: Connectivity,
-    Self: UndirectedGraph,
+    Self::NodeType: NodeBase<NodeIdType = NodeId>,
+    <Self::NodeType as NodeBase>::NodeEdgeType: NodeEdgeBase<NodeIdType = NodeId>,
 {
     fn get_is_connected(&self) -> Result<bool, &'static str> {
         self._get_is_connected(Self::NodeType::get_edges)
     }
 }
-pub trait ConnectivityDirected: GraphBase
+
+pub trait ConnectivityDirected: GraphBase + Connectivity + DirectedGraph
 where
-    Self: Connectivity,
-    Self: DirectedGraph,
-    <Self as GraphBase>::NodeType: DirectedNodeBase,
+    Self::NodeType: DirectedNodeBase,
+    <Self::NodeType as NodeBase>::NodeEdgeType: NodeEdgeBase<NodeIdType = NodeId>,
 {
     fn get_is_weakly_connected(&self) -> Result<bool, &'static str> {
         self._get_is_connected(Self::NodeType::get_edges)

--- a/src/dachshund/algorithms/coreness.rs
+++ b/src/dachshund/algorithms/coreness.rs
@@ -21,7 +21,11 @@ use priority_queue::PriorityQueue;
 type OrderedNodeSet = BTreeSet<NodeId>;
 type OrderedEdgeSet = BTreeSet<(NodeId, NodeId)>;
 
-pub trait Coreness: GraphBase + ConnectedComponents {
+pub trait Coreness: GraphBase + ConnectedComponents
+where
+    Self::NodeType: NodeBase<NodeIdType = NodeId, NodeSetType = FxHashSet<NodeId>>,
+    <Self::NodeType as NodeBase>::NodeEdgeType: NodeEdgeBase<NodeIdType = NodeId>,
+{
     fn _get_k_cores(&self, k: usize, removed: &mut FxHashSet<NodeId>) -> Vec<Vec<NodeId>> {
         // [BUG] This algorithm has a bug. See simple_graph.rs tests.
         let mut queue: OrderedNodeSet = self.get_ids_iter().cloned().collect();

--- a/src/dachshund/algorithms/eigenvector_centrality.rs
+++ b/src/dachshund/algorithms/eigenvector_centrality.rs
@@ -7,12 +7,17 @@
 use crate::dachshund::algorithms::adjacency_matrix::AdjacencyMatrix;
 use crate::dachshund::graph_base::GraphBase;
 use crate::dachshund::id_types::NodeId;
+use crate::dachshund::node::{NodeBase, NodeEdgeBase};
 use nalgebra::DMatrix;
 use std::collections::HashMap;
 
 type GraphMatrix = DMatrix<f64>;
 
-pub trait EigenvectorCentrality: GraphBase + AdjacencyMatrix {
+pub trait EigenvectorCentrality: GraphBase + AdjacencyMatrix
+where
+    Self::NodeType: NodeBase<NodeIdType = NodeId>,
+    <Self::NodeType as NodeBase>::NodeEdgeType: NodeEdgeBase<NodeIdType = NodeId>,
+{
     fn get_eigenvector_centrality(&self, eps: f64, max_iter: usize) -> HashMap<NodeId, f64> {
         let (adj_mat, node_ids) = self.get_adjacency_matrix();
         // Power iteration adaptation from

--- a/src/dachshund/algorithms/k_peaks.rs
+++ b/src/dachshund/algorithms/k_peaks.rs
@@ -14,7 +14,13 @@ use crate::dachshund::simple_undirected_graph_builder::SimpleUndirectedGraphBuil
 use crate::GraphBuilderBase;
 use std::collections::{HashMap, HashSet};
 
-pub trait KPeaks: GraphBase + Coreness {
+use fxhash::FxHashSet;
+
+pub trait KPeaks: GraphBase + Coreness
+where
+    Self::NodeType: NodeBase<NodeIdType = NodeId, NodeSetType = FxHashSet<NodeId>>,
+    <Self::NodeType as NodeBase>::NodeEdgeType: NodeEdgeBase<NodeIdType = NodeId>,
+{
     // Function that computes new coreness values from the set of nodes provided
     fn get_new_coreness_values(&self, nodes: &HashSet<NodeId>) -> HashMap<NodeId, usize> {
         let mut edges: Vec<(i64, i64)> = Vec::new();

--- a/src/dachshund/algorithms/laplacian.rs
+++ b/src/dachshund/algorithms/laplacian.rs
@@ -7,11 +7,16 @@
 use crate::dachshund::algorithms::adjacency_matrix::AdjacencyMatrix;
 use crate::dachshund::graph_base::GraphBase;
 use crate::dachshund::id_types::NodeId;
-use crate::dachshund::node::NodeBase;
+use crate::dachshund::node::{NodeBase, NodeEdgeBase};
 use nalgebra::{DMatrix, DVector};
 
 type GraphMatrix = DMatrix<f64>;
-pub trait Laplacian: GraphBase + AdjacencyMatrix {
+
+pub trait Laplacian: GraphBase + AdjacencyMatrix
+where
+    Self::NodeType: NodeBase<NodeIdType = NodeId>,
+    <Self::NodeType as NodeBase>::NodeEdgeType: NodeEdgeBase<NodeIdType = NodeId>,
+{
     fn get_degree_matrix(&self) -> (GraphMatrix, Vec<NodeId>) {
         let node_ids = self.get_ordered_node_ids();
         let diag: Vec<f64> = node_ids

--- a/src/dachshund/algorithms/shortest_paths.rs
+++ b/src/dachshund/algorithms/shortest_paths.rs
@@ -10,8 +10,10 @@ use crate::dachshund::node::{NodeBase, NodeEdgeBase};
 use std::collections::{HashMap, HashSet, VecDeque};
 
 type NodePredecessors = HashMap<NodeId, Vec<NodeId>>;
-pub trait ShortestPaths:
-    GraphBase<NodeType: NodeBase<NodeIdType = NodeId, NodeEdgeType: NodeEdgeBase<NodeIdType = NodeId>>>
+pub trait ShortestPaths: GraphBase
+where
+    Self::NodeType: NodeBase<NodeIdType = NodeId>,
+    <Self::NodeType as NodeBase>::NodeEdgeType: NodeEdgeBase<NodeIdType = NodeId>,
 {
     // Dikstra's algorithm for shortest paths. Returns distance and parent mappings
     fn get_shortest_paths(

--- a/src/dachshund/algorithms/transitivity.rs
+++ b/src/dachshund/algorithms/transitivity.rs
@@ -11,14 +11,10 @@ use fxhash::FxHashSet;
 use rand::distributions::WeightedIndex;
 use rand::prelude::*;
 
-pub trait Transitivity:
-    GraphBase<
-    NodeType: NodeBase<
-        NodeIdType = NodeId,
-        NodeEdgeType: NodeEdgeBase<NodeIdType = NodeId>,
-        NodeSetType = FxHashSet<NodeId>,
-    >,
->
+pub trait Transitivity: GraphBase
+where
+    Self::NodeType: NodeBase<NodeIdType = NodeId, NodeSetType = FxHashSet<NodeId>>,
+    <Self::NodeType as NodeBase>::NodeEdgeType: NodeEdgeBase<NodeIdType = NodeId>,
 {
     // Triangles : Number of triangles a node participates in.
     fn triangle_count(&self, node_id: NodeId) -> usize {

--- a/src/dachshund/node.rs
+++ b/src/dachshund/node.rs
@@ -223,8 +223,9 @@ impl NodeBase for SimpleNode {
     }
 }
 
-pub trait DirectedNodeBase:
-    NodeBase<NodeIdType = NodeId, NodeEdgeType: NodeEdgeBase<NodeIdType = NodeId>>
+pub trait DirectedNodeBase: NodeBase<NodeIdType = NodeId>
+where
+    Self::NodeEdgeType: NodeEdgeBase<NodeIdType = NodeId>,
 {
     fn get_in_neighbors(&self) -> Box<dyn Iterator<Item = &Self::NodeEdgeType> + '_>;
     fn get_out_neighbors(&self) -> Box<dyn Iterator<Item = &Self::NodeEdgeType> + '_>;

--- a/src/dachshund/simple_directed_graph.rs
+++ b/src/dachshund/simple_directed_graph.rs
@@ -12,15 +12,15 @@ use crate::dachshund::algorithms::connected_components::{
 use crate::dachshund::algorithms::connectivity::{Connectivity, ConnectivityDirected};
 use crate::dachshund::graph_base::GraphBase;
 use crate::dachshund::id_types::NodeId;
-use crate::dachshund::node::{DirectedNodeBase, NodeBase, SimpleDirectedNode};
+use crate::dachshund::node::{DirectedNodeBase, NodeBase, NodeEdgeBase, SimpleDirectedNode};
 use fxhash::FxHashMap;
 use std::collections::hash_map::{Keys, Values};
 use std::collections::HashSet;
 
-pub trait DirectedGraph
+pub trait DirectedGraph: GraphBase
 where
-    Self: GraphBase,
-    <Self as GraphBase>::NodeType: DirectedNodeBase,
+    Self::NodeType: DirectedNodeBase,
+    <Self::NodeType as NodeBase>::NodeEdgeType: NodeEdgeBase<NodeIdType = NodeId>,
 {
     fn is_acyclic(&self) -> bool {
         // from https://www.cs.hmc.edu/~keller/courses/cs60/s98/examples/acyclic/

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 #![feature(binary_heap_into_iter_sorted)]
-#![feature(associated_type_bounds)]
 extern crate clap;
 extern crate rand;
 extern crate thiserror;


### PR DESCRIPTION
`associated_type_bounds` is unstable and in flux. Currently this crate fails to compile with nightlies newer than 2023-05-03.

```console
error[E0271]: type mismatch resolving `<<Self as GraphBase>::NodeType as NodeBase>::NodeIdType == NodeId`
  --> src/dachshund/algorithms/betweenness.rs:14:23
   |
14 |     UndirectedGraph + Connectivity + ShortestPaths + ConnectivityUndirected
   |                       ^^^^^^^^^^^^ expected `NodeId`, found associated type
   |
   = note:       expected struct `NodeId`
           found associated type `<<Self as GraphBase>::NodeType as NodeBase>::NodeIdType`
   = help: consider constraining the associated type `<<Self as GraphBase>::NodeType as NodeBase>::NodeIdType` to `NodeId`
   = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
note: required by a bound in `Connectivity`
  --> src/dachshund/algorithms/connectivity.rs:18:34
   |
17 | pub trait Connectivity:
   |           ------------ required by a bound in this trait
18 |     GraphBase<NodeType: NodeBase<NodeIdType = NodeId, NodeEdgeType: NodeEdgeBase<NodeIdType = NodeId>>>
   |                                  ^^^^^^^^^^^^^^^^^^^ required by this bound in `Connectivity`
```